### PR TITLE
refactor: OAuth2 인증에서 Origin/Referer 헤더 기반 도메인 판별 로직으로 변경했습니다

### DIFF
--- a/src/main/java/com/example/chalpuplatform/customerfeedback/repository/CustomerFeedbackRepository.java
+++ b/src/main/java/com/example/chalpuplatform/customerfeedback/repository/CustomerFeedbackRepository.java
@@ -12,8 +12,6 @@ import java.util.List;
 
 @Repository
 public interface CustomerFeedbackRepository extends JpaRepository<CustomerFeedback, Long> {
-
-    List<CustomerFeedback> findByUserIdAndIsActiveTrueOrderByCreatedAtDesc(Long userId);
     
     Page<CustomerFeedback> findByUserIdAndIsActiveTrueOrderByCreatedAtDesc(Long userId, Pageable pageable);
     
@@ -38,8 +36,45 @@ public interface CustomerFeedbackRepository extends JpaRepository<CustomerFeedba
     @Query("""
         SELECT cf FROM CustomerFeedback cf
         JOIN FETCH cf.user u
-        LEFT JOIN FETCH u.userProfile up
         WHERE cf.id = :feedbackId AND cf.isActive = true
     """)
     CustomerFeedback findByIdWithUserProfile(@Param("feedbackId") Long feedbackId);
+
+    // 매장 피드백 조회 시 연관 엔티티 페치 조인
+    @Query("""
+        SELECT cf FROM CustomerFeedback cf
+        LEFT JOIN FETCH cf.foodItem
+        LEFT JOIN FETCH cf.store
+        LEFT JOIN FETCH cf.user
+        LEFT JOIN FETCH cf.survey
+        WHERE cf.store.id = :storeId
+        AND cf.isActive = true
+        ORDER BY cf.createdAt DESC
+    """)
+    Page<CustomerFeedback> findByStoreIdWithDetails(@Param("storeId") Long storeId, Pageable pageable);
+
+    // 사용자 피드백 조회 시 연관 엔티티 페치 조인
+    @Query("""
+        SELECT cf FROM CustomerFeedback cf
+        LEFT JOIN FETCH cf.foodItem
+        LEFT JOIN FETCH cf.store
+        LEFT JOIN FETCH cf.survey
+        WHERE cf.user.id = :userId
+        AND cf.isActive = true
+        ORDER BY cf.createdAt DESC
+    """)
+    Page<CustomerFeedback> findByUserIdWithDetails(@Param("userId") Long userId, Pageable pageable);
+
+    // 음식별 피드백 조회 시 연관 엔티티 페치 조인
+    @Query("""
+        SELECT cf FROM CustomerFeedback cf
+        LEFT JOIN FETCH cf.foodItem
+        LEFT JOIN FETCH cf.store
+        LEFT JOIN FETCH cf.user u
+        LEFT JOIN FETCH cf.survey
+        WHERE cf.foodItem.id = :foodItemId
+        AND cf.isActive = true
+        ORDER BY cf.createdAt DESC
+    """)
+    Page<CustomerFeedback> findByFoodItemIdWithDetails(@Param("foodItemId") Long foodItemId, Pageable pageable);
 }

--- a/src/main/java/com/example/chalpuplatform/customerfeedback/repository/FeedbackPhotoRepository.java
+++ b/src/main/java/com/example/chalpuplatform/customerfeedback/repository/FeedbackPhotoRepository.java
@@ -2,6 +2,8 @@ package com.example.chalpuplatform.customerfeedback.repository;
 
 import com.example.chalpuplatform.customerfeedback.domain.FeedbackPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,8 +12,16 @@ import java.util.List;
 public interface FeedbackPhotoRepository extends JpaRepository<FeedbackPhoto, Long> {
 
     List<FeedbackPhoto> findByFeedbackIdOrderByCreatedAtAsc(Long feedbackId);
-    
+
     void deleteByFeedbackId(Long feedbackId);
-    
+
     int countByFeedbackId(Long feedbackId);
+
+    // 배치 조회 - 여러 피드백의 사진을 한번에 조회
+    @Query("""
+        SELECT fp FROM FeedbackPhoto fp
+        WHERE fp.feedback.id IN :feedbackIds
+        ORDER BY fp.feedback.id, fp.createdAt
+    """)
+    List<FeedbackPhoto> findPhotosByFeedbackIds(@Param("feedbackIds") List<Long> feedbackIds);
 }

--- a/src/main/java/com/example/chalpuplatform/customerfeedback/service/CustomerFeedbackService.java
+++ b/src/main/java/com/example/chalpuplatform/customerfeedback/service/CustomerFeedbackService.java
@@ -9,6 +9,7 @@ import com.example.chalpuplatform.customerfeedback.repository.FeedbackPhotoRepos
 import com.example.chalpuplatform.user.domain.User;
 import com.example.chalpuplatform.user.domain.UserProfile;
 import com.example.chalpuplatform.user.repository.UserRepository;
+import com.example.chalpuplatform.user.repository.UserProfileRepository;
 
 import com.example.chalpuplatform.survey.domain.Survey;
 import com.example.chalpuplatform.survey.domain.SurveyAnswer;
@@ -46,6 +47,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Optional;
+import java.util.Collections;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -59,6 +61,7 @@ public class CustomerFeedbackService {
     private final FeedbackPhotoRepository photoRepository;
     private final SurveyAnswerRepository answerRepository;
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
     private final FoodItemRepository foodItemRepository;
     private final StoreRepository storeRepository;
     private final SurveyRepository surveyRepository;
@@ -86,12 +89,14 @@ public class CustomerFeedbackService {
         feedback.setIsViewed(false); // 새 피드백은 읽지 않은 상태로 설정
 
         // 현재 고객 입맛을 스냅샷으로 저장
-        if (user.getUserProfile() != null && user.getUserProfile().getCustomerTaste() != null) {
-            CustomerTaste taste = user.getUserProfile().getCustomerTaste();
-            feedback.setSpicyLevelSnapshot(taste.getSpicyLevel());
-            feedback.setMealAmountSnapshot(taste.getMealAmount());
-            feedback.setMealSpendingSnapshot(taste.getMealSpending());
-        }
+        userProfileRepository.findByUserId(user.getId()).ifPresent(userProfile -> {
+            if (userProfile.getCustomerTaste() != null) {
+                CustomerTaste taste = userProfile.getCustomerTaste();
+                feedback.setSpicyLevelSnapshot(taste.getSpicyLevel());
+                feedback.setMealAmountSnapshot(taste.getMealAmount());
+                feedback.setMealSpendingSnapshot(taste.getMealSpending());
+            }
+        });
 
         CustomerFeedback savedFeedback = feedbackRepository.save(feedback);
 
@@ -101,10 +106,11 @@ public class CustomerFeedbackService {
             saveFeedbackPhotos(savedFeedback, request.getPhotoS3Keys());
         }
 
-        if (user.getUserProfile() != null) {
-            user.getUserProfile().incrementFeedbackCount();
-            user.getUserProfile().incrementRewardCount();
-        }
+        userProfileRepository.findByUserId(user.getId()).ifPresent(userProfile -> {
+            userProfile.incrementFeedbackCount();
+            userProfile.incrementRewardCount();
+            userProfileRepository.save(userProfile);
+        });
 
         log.info("고객 피드백 생성 완료: feedbackId={}, userId={}, foodId={}, reward_count_earned=1",
                 savedFeedback.getId(), userDetails.getId(), request.getFoodId());
@@ -138,12 +144,6 @@ public class CustomerFeedbackService {
                     
                     SurveyAnswer answer = SurveyAnswer.createAnswer(feedback, question, 
                             request.getAnswerText(), request.getNumericValue());
-                    
-                //     // 답변 유효성 검증
-                //     if (!answer.isValidAnswer()) {
-                //         throw new SurveyException(ErrorMessage.SURVEY_ANSWER_INVALID);
-                //     }
-                    
                     return answer;
                 })
                 .collect(Collectors.toList());
@@ -167,21 +167,38 @@ public class CustomerFeedbackService {
     }
 
     @Transactional(readOnly = true)
-    public List<CustomerFeedbackResponse> getUserFeedbacks(UserDetailsImpl userDetails) {
-        List<CustomerFeedback> feedbacks = feedbackRepository
-                .findByUserIdAndIsActiveTrueOrderByCreatedAtDesc(userDetails.getId());
-
-        return feedbacks.stream()
-                .map(this::mapToCustomerFeedbackResponse)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
     public Page<CustomerFeedbackResponse> getUserFeedbacks(UserDetailsImpl userDetails, Pageable pageable) {
+        // 페치 조인으로 연관 엔티티 함께 조회
         Page<CustomerFeedback> feedbacks = feedbackRepository
-                .findByUserIdAndIsActiveTrueOrderByCreatedAtDesc(userDetails.getId(), pageable);
+                .findByUserIdWithDetails(userDetails.getId(), pageable);
 
-        return feedbacks.map(this::mapToCustomerFeedbackResponse);
+        if (feedbacks.isEmpty()) {
+            return Page.empty();
+        }
+
+        // 피드백 ID 추출
+        List<Long> feedbackIds = feedbacks.stream()
+                .map(CustomerFeedback::getId)
+                .collect(Collectors.toList());
+
+        // 답변 배치 조회 (question 포함)
+        Map<Long, List<SurveyAnswer>> answersMap = answerRepository
+                .findAnswersByFeedbackIdsWithQuestion(feedbackIds)
+                .stream()
+                .collect(Collectors.groupingBy(sa -> sa.getFeedback().getId()));
+
+        // 사진 배치 조회
+        Map<Long, List<FeedbackPhoto>> photosMap = photoRepository
+                .findPhotosByFeedbackIds(feedbackIds)
+                .stream()
+                .collect(Collectors.groupingBy(fp -> fp.getFeedback().getId()));
+
+        // DTO 변환
+        return feedbacks.map(feedback -> mapToCustomerFeedbackResponseWithData(
+                feedback,
+                answersMap.getOrDefault(feedback.getId(), Collections.emptyList()),
+                photosMap.getOrDefault(feedback.getId(), Collections.emptyList())
+        ));
     }
 
     @Transactional(readOnly = true)
@@ -192,9 +209,41 @@ public class CustomerFeedbackService {
         }
 
         Page<CustomerFeedback> feedbacks = feedbackRepository
-                .findByStoreIdAndIsActiveTrueOrderByCreatedAtDesc(storeId, pageable);
+                .findByStoreIdWithDetails(storeId, pageable);
+        if (feedbacks.isEmpty()) {
+            return Page.empty();
+        }
 
-        return feedbacks.map(this::mapToOwnerFeedbackResponse);
+        // 피드백 ID 추출
+        List<Long> feedbackIds = feedbacks.stream()
+                .map(CustomerFeedback::getId)
+                .collect(Collectors.toList());
+
+        // 사장님 메시지만 효율적으로 조회
+        Map<Long, String> ownerMessagesMap = answerRepository
+                .findOwnerMessagesByFeedbackIds(feedbackIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],    // feedback_id
+                        row -> (String) row[1]    // answer_text
+                ));
+
+        // 사진 배치 조회
+        Map<Long, List<String>> photosMap = photoRepository
+                .findPhotosByFeedbackIds(feedbackIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        fp -> fp.getFeedback().getId(),
+                        Collectors.mapping(FeedbackPhoto::getImageUrl, Collectors.toList())
+                ));
+
+        // DTO 변환
+        return feedbacks.map(feedback -> {
+            OwnerFeedbackResponse response = OwnerFeedbackResponse.from(feedback);
+            response.setOwnerMessage(ownerMessagesMap.get(feedback.getId()));
+            response.setPhotoUrls(photosMap.getOrDefault(feedback.getId(), Collections.emptyList()));
+            return response;
+        });
     }
 
     @Transactional(readOnly = true)
@@ -202,15 +251,20 @@ public class CustomerFeedbackService {
         CustomerFeedback feedback = feedbackRepository.findById(feedbackId)
                 .orElseThrow(() -> new FeedbackException(ErrorMessage.FEEDBACK_NOT_FOUND));
 
-        return mapToCustomerFeedbackResponse(feedback);
+        // 답변은 question과 함께 조회
+        List<SurveyAnswer> answers = answerRepository.findByFeedbackIdWithQuestion(feedbackId);
+
+        // 사진 조회
+        List<FeedbackPhoto> photos = photoRepository.findByFeedbackIdOrderByCreatedAtAsc(feedbackId);
+
+        return mapToCustomerFeedbackResponseWithData(feedback, answers, photos);
     }
 
 
-    // 고객용 응답 매핑 (고객 정보 제외)
-    private CustomerFeedbackResponse mapToCustomerFeedbackResponse(CustomerFeedback feedback) {
-        List<SurveyAnswer> answers = answerRepository.findByFeedbackIdOrderByQuestionId(feedback.getId());
-        List<FeedbackPhoto> photos = photoRepository.findByFeedbackIdOrderByCreatedAtAsc(feedback.getId());
-
+    // 고객용 응답 매핑 (고객 정보 제외) - 데이터를 받아서 처리
+    private CustomerFeedbackResponse mapToCustomerFeedbackResponseWithData(CustomerFeedback feedback,
+                                                                          List<SurveyAnswer> answers,
+                                                                          List<FeedbackPhoto> photos) {
         return CustomerFeedbackResponse.builder()
                 .feedbackId(feedback.getId())
                 .foodName(feedback.getFoodItem().getFoodName())
@@ -224,6 +278,13 @@ public class CustomerFeedbackService {
                         .map(FeedbackPhoto::getImageUrl)
                         .collect(Collectors.toList()))
                 .build();
+    }
+
+    // 기존 메서드는 단일 조회용으로 유지
+    private CustomerFeedbackResponse mapToCustomerFeedbackResponse(CustomerFeedback feedback) {
+        List<SurveyAnswer> answers = answerRepository.findByFeedbackIdOrderByQuestionId(feedback.getId());
+        List<FeedbackPhoto> photos = photoRepository.findByFeedbackIdOrderByCreatedAtAsc(feedback.getId());
+        return mapToCustomerFeedbackResponseWithData(feedback, answers, photos);
     }
 
     // 사장님용 응답 매핑 (고객 정보 포함)
@@ -326,6 +387,7 @@ public class CustomerFeedbackService {
         }
     }
 
+    @Transactional(readOnly = true)
     public Page<OwnerFeedbackResponse> getFoodFeedbacks(Long foodId, UserDetailsImpl userDetails, Pageable pageable) {
         // 음식이 속한 매장 조회
         FoodItem foodItem = foodItemRepository.findById(foodId)
@@ -336,10 +398,44 @@ public class CustomerFeedbackService {
             throw new FeedbackException(ErrorMessage.STORE_ACCESS_DENIED);
         }
 
+        // 페치 조인으로 연관 엔티티 함께 조회
         Page<CustomerFeedback> feedbacks = feedbackRepository
-                .findByFoodItemIdAndIsActiveTrueOrderByCreatedAtDesc(foodId, pageable);
+                .findByFoodItemIdWithDetails(foodId, pageable);
 
-        return feedbacks.map(this::mapToOwnerFeedbackResponse);
+        if (feedbacks.isEmpty()) {
+            return Page.empty();
+        }
+
+        // 피드백 ID 추출
+        List<Long> feedbackIds = feedbacks.stream()
+                .map(CustomerFeedback::getId)
+                .collect(Collectors.toList());
+
+        // 사장님 메시지만 효율적으로 조회
+        Map<Long, String> ownerMessagesMap = answerRepository
+                .findOwnerMessagesByFeedbackIds(feedbackIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],    // feedback_id
+                        row -> (String) row[1]    // answer_text
+                ));
+
+        // 사진 배치 조회
+        Map<Long, List<String>> photosMap = photoRepository
+                .findPhotosByFeedbackIds(feedbackIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        fp -> fp.getFeedback().getId(),
+                        Collectors.mapping(FeedbackPhoto::getImageUrl, Collectors.toList())
+                ));
+
+        // DTO 변환
+        return feedbacks.map(feedback -> {
+            OwnerFeedbackResponse response = OwnerFeedbackResponse.from(feedback);
+            response.setOwnerMessage(ownerMessagesMap.get(feedback.getId()));
+            response.setPhotoUrls(photosMap.getOrDefault(feedback.getId(), Collections.emptyList()));
+            return response;
+        });
     }
 
 

--- a/src/main/java/com/example/chalpuplatform/fooditem/service/FoodItemService.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/service/FoodItemService.java
@@ -64,22 +64,16 @@ public class FoodItemService {
      */
     @Transactional
     public FoodItemResponse createFoodItem(Long storeId, FoodItemRequest foodItemRequest, Long userId) {
-        try {
-            validateUserStoreAccess(userId, storeId);
-            Store store = findStoreById(storeId);
-            
-            FoodItem foodItem = FoodItem.createFoodItem(store, foodItemRequest);
-            FoodItem savedFoodItem = foodItemRepository.save(foodItem);
-            
-            log.info("event=food_item_created, food_item_id={}, store_id={}, user_id={}", 
-                    savedFoodItem.getId(), storeId, userId);
-            
-            return FoodItemResponse.from(savedFoodItem);
-        } catch (Exception e) {
-            log.error("event=food_item_creation_failed, store_id={}, user_id={}, error_message={}", 
-                    storeId, userId, e.getMessage(), e);
-            throw new FoodException(ErrorMessage.FOOD_CREATE_FAILED);
-        }
+        validateUserStoreAccess(userId, storeId);
+        Store store = findStoreById(storeId);
+
+        FoodItem foodItem = FoodItem.createFoodItem(store, foodItemRequest);
+        FoodItem savedFoodItem = foodItemRepository.save(foodItem);
+
+        log.info("event=food_item_created, food_item_id={}, store_id={}, user_id={}",
+                savedFoodItem.getId(), storeId, userId);
+
+        return FoodItemResponse.from(savedFoodItem);
     }
 
     /**

--- a/src/main/java/com/example/chalpuplatform/oauth/config/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/config/CustomAuthorizationRequestResolver.java
@@ -1,6 +1,8 @@
 package com.example.chalpuplatform.oauth.config;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
@@ -10,12 +12,17 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @Component
 public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
 
     private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
-    private static final String CUSTOMER_BASE_URI = "/api/oauth2/authorization/customer";
-    private static final String OWNER_BASE_URI = "/api/oauth2/authorization/owner";
+
+    @Value("${oauth2.redirect.owner-domain:owner.chalpu.com}")
+    private String ownerDomain;
+
+    @Value("${oauth2.redirect.customer-domain:customer.chalpu.com}")
+    private String customerDomain;
 
     public CustomAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
         this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
@@ -24,59 +31,63 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        OAuth2AuthorizationRequest authorizationRequest = null;
-        
-        // customer 경로 처리
-        if (path.startsWith(CUSTOMER_BASE_URI)) {
-            String newPath = path.replace("/customer", "");
-            authorizationRequest = resolveRequest(request, newPath);
-            if (authorizationRequest != null) {
-                return customizeAuthorizationRequest(authorizationRequest, "customer");
-            }
+        OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request);
+
+        if (authorizationRequest != null) {
+            String userType = determineUserTypeFromDomain(request);
+            return customizeAuthorizationRequest(authorizationRequest, userType);
         }
-        
-        // owner 경로 처리
-        if (path.startsWith(OWNER_BASE_URI)) {
-            String newPath = path.replace("/owner", "");
-            authorizationRequest = resolveRequest(request, newPath);
-            if (authorizationRequest != null) {
-                return customizeAuthorizationRequest(authorizationRequest, "owner");
-            }
-        }
-        
-        // 기본 경로 처리
-        if (defaultResolver != null) {
-            return defaultResolver.resolve(request);
-        }
-        
+
         return null;
     }
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
-        if (defaultResolver != null) {
-            OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request, clientRegistrationId);
-            String path = request.getRequestURI();
-            
-            if (path.contains("/customer/")) {
-                return customizeAuthorizationRequest(authorizationRequest, "customer");
-            } else if (path.contains("/owner/")) {
-                return customizeAuthorizationRequest(authorizationRequest, "owner");
-            }
-            
-            return authorizationRequest;
+        OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request, clientRegistrationId);
+
+        if (authorizationRequest != null) {
+            String userType = determineUserTypeFromDomain(request);
+            log.debug("OAuth2 인증 요청 - Host: {}, UserType: {}, Provider: {}",
+                    request.getServerName(), userType, clientRegistrationId);
+            return customizeAuthorizationRequest(authorizationRequest, userType);
         }
+
         return null;
     }
 
-    private OAuth2AuthorizationRequest resolveRequest(HttpServletRequest request, String path) {
-        if (defaultResolver != null) {
-            HttpServletRequest modifiedRequest = new HttpServletRequestWrapper(request, path);
-            return defaultResolver.resolve(modifiedRequest);
+    /**
+     * 도메인으로부터 사용자 타입 결정
+     */
+    private String determineUserTypeFromDomain(HttpServletRequest request) {
+        String origin = request.getHeader("Origin");
+        if (origin != null) {
+            log.debug("Origin 헤더 감지: {}", origin);
+            if (origin.contains(ownerDomain)) {
+                log.info("Owner 도메인에서 OAuth2 요청: {}", origin);
+                return "owner";
+            } else if (origin.contains(customerDomain)) {
+                log.info("Customer 도메인에서 OAuth2 요청: {}", origin);
+                return "customer";
+            }
         }
-        return null;
+
+        String referer = request.getHeader("Referer");
+        if (referer != null) {
+            log.debug("Referer 헤더 감지: {}", referer);
+            if (referer.contains(ownerDomain)) {
+                log.info("Owner 도메인에서 OAuth2 요청 (Referer): {}", referer);
+                return "owner";
+            } else if (referer.contains(customerDomain)) {
+                log.info("Customer 도메인에서 OAuth2 요청 (Referer): {}", referer);
+                return "customer";
+            }
+        }
+
+        // 3. 기본값은 customer
+        log.debug("도메인을 판단할 수 없음. 기본값 customer 사용 (Origin: {}, Referer: {})", origin, referer);
+        return "customer";
     }
+
 
     private OAuth2AuthorizationRequest customizeAuthorizationRequest(
             OAuth2AuthorizationRequest authorizationRequest, String userType) {
@@ -91,20 +102,5 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
         return OAuth2AuthorizationRequest.from(authorizationRequest)
                 .additionalParameters(additionalParameters)
                 .build();
-    }
-    
-    // HttpServletRequest Wrapper 클래스
-    private static class HttpServletRequestWrapper extends jakarta.servlet.http.HttpServletRequestWrapper {
-        private final String requestURI;
-        
-        public HttpServletRequestWrapper(HttpServletRequest request, String requestURI) {
-            super(request);
-            this.requestURI = requestURI;
-        }
-        
-        @Override
-        public String getRequestURI() {
-            return requestURI;
-        }
     }
 }

--- a/src/main/java/com/example/chalpuplatform/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/config/SecurityConfig.java
@@ -87,6 +87,9 @@ public class SecurityConfig {
         configuration.setAllowedOriginPatterns(Arrays.asList(
                 "http://localhost:3000",
                 "http://127.0.0.1:3000",
+                "https://owner.chalpu.com",
+                "https://customer.chalpu.com",
+                "https://*.chalpu.com",  // 모든 chalpu.com 서브도메인 허용
                 "*"
         ));
 

--- a/src/main/java/com/example/chalpuplatform/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -10,12 +10,18 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Component
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
-    @Value("${oauth2.redirect.failure-url}")
-    private String redirectFailureUrl;
+    @Value("${oauth2.redirect.failure-path:#{'/oauth2/failure'}}")
+    private String failurePath;
+    @Value("${oauth2.redirect.owner-domain:#{'owner.chalpu.com'}}")
+    private String ownerDomain;
+    @Value("${oauth2.redirect.customer-domain:#{'customer.chalpu.com'}}")
+    private String customerDomain;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -24,11 +30,69 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
         String errorMessage = exception.getLocalizedMessage();
         log.error("OAuth2 인증 실패: {}", errorMessage, exception);
 
+        // Origin/Referer 헤더로 클라이언트 도메인 결정
+        String clientDomain = determineClientDomain(request);
+        String redirectDomain = determineRedirectDomain(clientDomain);
+
+        // 에러 메시지 인코딩
+        String encodedMessage = URLEncoder.encode("OAuth 인증에 실패했습니다: " + errorMessage, StandardCharsets.UTF_8);
+
         // UriComponentsBuilder를 사용하여 일관된 방식으로 리다이렉트 URL 생성
-        String targetUrl = UriComponentsBuilder.fromUriString(redirectFailureUrl)
-                .queryParam("message", "OAuth 인증에 실패했습니다: " + errorMessage)
+        String targetUrl = UriComponentsBuilder.fromHttpUrl("https://" + redirectDomain)
+                .path(failurePath)
+                .queryParam("error", encodedMessage)
                 .build().toUriString();
 
+        log.info("OAuth2 인증 실패 리다이렉트: {}", targetUrl);
+
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    /**
+     * Origin/Referer 헤더를 통해 클라이언트 도메인 결정
+     */
+    private String determineClientDomain(HttpServletRequest request) {
+        // 1. Origin 헤더 확인 (CORS 요청시)
+        String origin = request.getHeader("Origin");
+        if (origin != null) {
+            log.debug("Origin 헤더 감지: {}", origin);
+            if (origin.contains(ownerDomain)) {
+                log.info("Owner 도메인에서 OAuth2 실패 처리: {}", origin);
+                return "owner";
+            } else if (origin.contains(customerDomain)) {
+                log.info("Customer 도메인에서 OAuth2 실패 처리: {}", origin);
+                return "customer";
+            }
+        }
+
+        // 2. Referer 헤더 확인 (일반 요청시)
+        String referer = request.getHeader("Referer");
+        if (referer != null) {
+            log.debug("Referer 헤더 감지: {}", referer);
+            if (referer.contains(ownerDomain)) {
+                log.info("Owner 도메인에서 OAuth2 실패 처리 (Referer): {}", referer);
+                return "owner";
+            } else if (referer.contains(customerDomain)) {
+                log.info("Customer 도메인에서 OAuth2 실패 처리 (Referer): {}", referer);
+                return "customer";
+            }
+        }
+
+        // 3. 기본값은 customer
+        log.debug("도메인을 판단할 수 없음. 기본값 customer 사용 (Origin: {}, Referer: {})", origin, referer);
+        return "customer";
+    }
+
+    /**
+     * 리다이렉트할 도메인 결정
+     */
+    private String determineRedirectDomain(String clientDomain) {
+        // 클라이언트 도메인이 owner이면 owner 도메인으로 리다이렉트
+        if ("owner".equals(clientDomain)) {
+            return ownerDomain;
+        }
+
+        // 기본값은 customer 도메인
+        return customerDomain;
     }
 }

--- a/src/main/java/com/example/chalpuplatform/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -27,10 +27,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final AuthCodeRepository authCodeRepository;
     private final UserLoginHistoryRepository userLoginHistoryRepository;
 
-    @Value("${oauth2.redirect.success-url}")
-    private String redirectSuccessUrl;
-    @Value("${oauth2.redirect.failure-url}")
-    private String redirectFailureUrl;
+    @Value("${oauth2.redirect.success-path:#{'/oauth2/success'}}")
+    private String successPath;
+    @Value("${oauth2.redirect.failure-path:#{'/oauth2/failure'}}")
+    private String failurePath;
+    @Value("${oauth2.redirect.owner-domain:#{''}}")
+    private String ownerDomain;
+    @Value("${oauth2.redirect.customer-domain:#{''}}")
+    private String customerDomain;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -65,13 +69,13 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 log.error("로그인 이력 저장 실패: userId={}, error={}", userDetails.getId(), e.getMessage());
             }
 
-            log.info("OAuth2 로그인 성공 및 인증 코드 생성: userId={}, email={}, code={}", 
-                    userDetails.getId(), userDetails.getEmail(), authCode);
+            log.info("OAuth2 로그인 성공 및 인증 코드 생성: userId={}, email={}, code={}, role={}",
+                    userDetails.getId(), userDetails.getEmail(), authCode, userRole);
 
-            // 인증 코드만 URL 파라미터로 전달
-            String targetUrl = UriComponentsBuilder.fromUriString(redirectSuccessUrl)
-                    .queryParam("code", authCode)
-                    .build().toUriString();
+            // 도메인 기반 리다이렉트 URL 결정
+            String targetUrl = buildRedirectUrl(request, userRole, authCode, true);
+
+            log.info("OAuth2 인증 성공 리다이렉트: {}", targetUrl);
 
             // 리다이렉트 수행
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
@@ -80,11 +84,74 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             log.error("OAuth2 인증 성공 처리 중 오류 발생: {}", e.getMessage(), e);
 
             // 오류 발생 시 실패 URL로 리다이렉트
-            String errorUrl = UriComponentsBuilder.fromUriString(redirectFailureUrl)
-                    .queryParam("error", URLEncoder.encode("로그인 처리 중 오류가 발생했습니다.", StandardCharsets.UTF_8))
-                    .build().toUriString();
+            String errorUrl = buildRedirectUrl(request, null,
+                    URLEncoder.encode("로그인 처리 중 오류가 발생했습니다.", StandardCharsets.UTF_8), false);
 
             getRedirectStrategy().sendRedirect(request, response, errorUrl);
         }
+    }
+
+    /**
+     * 도메인 기반으로 리다이렉트 URL 생성
+     */
+    private String buildRedirectUrl(HttpServletRequest request, String userRole, String param, boolean isSuccess) {
+        // Origin/Referer 헤더로 클라이언트 도메인 결정
+        String clientDomain = determineClientDomain(request);
+        String redirectDomain = determineRedirectDomain(clientDomain, userRole);
+        String path = isSuccess ? successPath : failurePath;
+        String paramName = isSuccess ? "code" : "error";
+
+        return UriComponentsBuilder.fromHttpUrl("https://" + redirectDomain)
+                .path(path)
+                .queryParam(paramName, param)
+                .build().toUriString();
+    }
+
+    /**
+     * Origin/Referer 헤더를 통해 클라이언트 도메인 결정
+     */
+    private String determineClientDomain(HttpServletRequest request) {
+        // 1. Origin 헤더 확인 (CORS 요청시)
+        String origin = request.getHeader("Origin");
+        if (origin != null) {
+            log.debug("Origin 헤더 감지: {}", origin);
+            if (origin.contains(ownerDomain)) {
+                log.info("Owner 도메인에서 OAuth2 성공 처리: {}", origin);
+                return "owner";
+            } else if (origin.contains(customerDomain)) {
+                log.info("Customer 도메인에서 OAuth2 성공 처리: {}", origin);
+                return "customer";
+            }
+        }
+
+        // 2. Referer 헤더 확인 (일반 요청시)
+        String referer = request.getHeader("Referer");
+        if (referer != null) {
+            log.debug("Referer 헤더 감지: {}", referer);
+            if (referer.contains(ownerDomain)) {
+                log.info("Owner 도메인에서 OAuth2 성공 처리 (Referer): {}", referer);
+                return "owner";
+            } else if (referer.contains(customerDomain)) {
+                log.info("Customer 도메인에서 OAuth2 성공 처리 (Referer): {}", referer);
+                return "customer";
+            }
+        }
+
+        // 3. 기본값은 customer
+        log.debug("도메인을 판단할 수 없음. 기본값 customer 사용 (Origin: {}, Referer: {})", origin, referer);
+        return "customer";
+    }
+
+    /**
+     * 리다이렉트할 도메인 결정
+     */
+    private String determineRedirectDomain(String clientDomain, String userRole) {
+        // 1. 클라이언트 도메인이 owner이거나 role이 OWNER인 경우
+        if ("owner".equals(clientDomain) || "ROLE_OWNER".equals(userRole)) {
+            return !ownerDomain.isEmpty() ? ownerDomain : "owner.chalpu.com";
+        }
+
+        // 2. 기본값은 customer 도메인
+        return !customerDomain.isEmpty() ? customerDomain : "customer.chalpu.com";
     }
 }

--- a/src/main/java/com/example/chalpuplatform/oauth/strategy/CustomerUserTypeStrategy.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/strategy/CustomerUserTypeStrategy.java
@@ -5,6 +5,7 @@ import com.example.chalpuplatform.user.domain.Role;
 import com.example.chalpuplatform.user.domain.User;
 import com.example.chalpuplatform.user.domain.UserProfile;
 import com.example.chalpuplatform.user.repository.UserRepository;
+import com.example.chalpuplatform.user.repository.UserProfileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -20,23 +21,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class CustomerUserTypeStrategy implements UserTypeStrategy {
     
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
     
     @Override
     @Transactional
     public OAuth2User processUser(User user, OAuth2User oAuth2User) {
         user.setRole(Role.ROLE_CUSTOMER);
-        
+
+        // User를 먼저 저장
+        User savedUser = userRepository.save(user);
+
         // UserProfile이 없으면 생성
-        if (user.getUserProfile() == null) {
-            UserProfile profile = UserProfile.create(user);
-            user.setUserProfile(profile);
-            log.info("고객 사용자 프로필 생성: {}", user.getEmail());
+        if (!userProfileRepository.findByUserId(savedUser.getId()).isPresent()) {
+            UserProfile profile = UserProfile.create(savedUser);
+            userProfileRepository.save(profile);
+            log.info("고객 사용자 프로필 생성: {}", savedUser.getEmail());
         }
-        
-        userRepository.save(user);
-        log.info("고객 사용자로 처리 완료: {}", user.getEmail());
-        
-        return UserDetailsImpl.build(user, oAuth2User.getAttributes());
+
+        log.info("고객 사용자로 처리 완료: {}", savedUser.getEmail());
+
+        return UserDetailsImpl.build(savedUser, oAuth2User.getAttributes());
     }
     
     @Override

--- a/src/main/java/com/example/chalpuplatform/reward/service/RewardService.java
+++ b/src/main/java/com/example/chalpuplatform/reward/service/RewardService.java
@@ -6,6 +6,7 @@ import com.example.chalpuplatform.common.exception.RewardException;
 import com.example.chalpuplatform.user.domain.User;
 import com.example.chalpuplatform.user.domain.UserProfile;
 import com.example.chalpuplatform.user.repository.UserRepository;
+import com.example.chalpuplatform.user.repository.UserProfileRepository;
 import com.example.chalpuplatform.reward.domain.Reward;
 import com.example.chalpuplatform.reward.domain.RewardRedemption;
 import com.example.chalpuplatform.reward.dto.RewardRedemptionRequest;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,6 +33,7 @@ public class RewardService {
     private final RewardRepository rewardRepository;
     private final RewardRedemptionRepository redemptionRepository;
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
 
     @Transactional(readOnly = true)
     public List<RewardResponse> getAvailableRewards() {
@@ -54,12 +57,13 @@ public class RewardService {
     }
 
     private boolean canUserAffordReward(User user, Reward reward) {
-        if (user.getUserProfile() == null) {
+        Optional<UserProfile> userProfile = userProfileRepository.findByUserId(user.getId());
+        if (!userProfile.isPresent()) {
             return false;
         }
-        Integer userRewardCount = user.getUserProfile().getRewardCount();
+        Integer userRewardCount = userProfile.get().getRewardCount();
         Integer requiredCount = reward.getRequiredCount();
-        
+
         return userRewardCount != null && requiredCount != null && userRewardCount >= requiredCount;
     }
 
@@ -67,9 +71,8 @@ public class RewardService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
 
-        if (user.getUserProfile() == null) {
-            throw new RewardException(ErrorMessage.INSUFFICIENT_REWARD_COUNT);
-        }
+        UserProfile userProfile = userProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new RewardException(ErrorMessage.INSUFFICIENT_REWARD_COUNT));
 
         Reward reward = rewardRepository.findById(request.getRewardId())
                 .orElseThrow(() -> new RewardException(ErrorMessage.REWARD_NOT_FOUND));
@@ -84,19 +87,20 @@ public class RewardService {
 
         // 리워드 횟수 차감
         try {
-            user.getUserProfile().decrementRewardCount(reward.getRequiredCount());
+            userProfile.decrementRewardCount(reward.getRequiredCount());
+            userProfileRepository.save(userProfile);
         } catch (IllegalArgumentException e) {
             throw new RewardException(ErrorMessage.INSUFFICIENT_REWARD_COUNT);
         }
 
         RewardRedemption redemption = RewardRedemption.createRedemption(
-                user, reward, user.getUserProfile().getRewardCount());
+                user, reward, userProfile.getRewardCount());
 
         RewardRedemption savedRedemption = redemptionRepository.save(redemption);
 
-        log.info("리워드 교환 완료: userId={}, rewardId={}, required_count={}, remaining_count={}", 
-                userId, request.getRewardId(), reward.getRequiredCount(), 
-                user.getUserProfile().getRewardCount());
+        log.info("리워드 교환 완료: userId={}, rewardId={}, required_count={}, remaining_count={}",
+                userId, request.getRewardId(), reward.getRequiredCount(),
+                userProfile.getRewardCount());
 
         return RewardRedemptionResponse.from(savedRedemption);
     }
@@ -142,11 +146,12 @@ public class RewardService {
     public boolean isEligibleForReward(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
-        
-        if (user.getUserProfile() == null) {
+
+        Optional<UserProfile> userProfile = userProfileRepository.findByUserId(userId);
+        if (!userProfile.isPresent()) {
             return false;
         }
-        
-        return user.getUserProfile().getRewardCount() != null && user.getUserProfile().getRewardCount() > 0;
+
+        return userProfile.get().getRewardCount() != null && userProfile.get().getRewardCount() > 0;
     }
 }

--- a/src/main/java/com/example/chalpuplatform/survey/repository/SurveyAnswerRepository.java
+++ b/src/main/java/com/example/chalpuplatform/survey/repository/SurveyAnswerRepository.java
@@ -16,33 +16,6 @@ public interface SurveyAnswerRepository extends JpaRepository<SurveyAnswer, Long
 
     List<SurveyAnswer> findByFeedbackIdOrderByQuestionId(Long feedbackId);
 
-    Optional<SurveyAnswer> findByFeedbackIdAndQuestionId(Long feedbackId, Long questionId);
-
-    List<SurveyAnswer> findByQuestionId(Long questionId);
-    
-    void deleteByFeedbackId(Long feedbackId);
-    
-    // JAR 분석용 쿼리
-    @Query("""
-        SELECT sa.question.id, sa.question.jarAttribute, sa.numericValue, 
-               (SELECT osa.numericValue FROM SurveyAnswer osa 
-                WHERE osa.feedback.id = f.id 
-                AND osa.question.id = 10)
-        FROM SurveyAnswer sa
-        JOIN sa.feedback f
-        JOIN sa.question sq
-        WHERE sq.jarAttribute IS NOT NULL
-        AND f.store.id = :storeId
-        AND f.createdAt BETWEEN :startDate AND :endDate
-        AND EXISTS (SELECT 1 FROM SurveyAnswer osa2 
-                    WHERE osa2.feedback.id = f.id 
-                    AND osa2.question.id = 10 
-                    AND osa2.numericValue IS NOT NULL)
-        """)
-    List<Object[]> findJARDataByStore(@Param("storeId") Long storeId,
-                                      @Param("startDate") LocalDateTime startDate,
-                                      @Param("endDate") LocalDateTime endDate);
-    
     @Query("""
         SELECT sa.question.id, sa.question.jarAttribute, sa.numericValue,
                (SELECT osa.numericValue FROM SurveyAnswer osa 
@@ -93,4 +66,31 @@ public interface SurveyAnswerRepository extends JpaRepository<SurveyAnswer, Long
     List<Object[]> findNPSDataByFoodItem(@Param("foodItemId") Long foodItemId,
                                          @Param("startDate") LocalDateTime startDate,
                                          @Param("endDate") LocalDateTime endDate);
+
+    // 배치 조회 - question 포함
+    @Query("""
+        SELECT sa FROM SurveyAnswer sa
+        JOIN FETCH sa.question
+        WHERE sa.feedback.id IN :feedbackIds
+        ORDER BY sa.feedback.id, sa.question.id
+    """)
+    List<SurveyAnswer> findAnswersByFeedbackIdsWithQuestion(@Param("feedbackIds") List<Long> feedbackIds);
+
+    // 사장님께 한마디만 효율적으로 조회
+    @Query("""
+        SELECT sa.feedback.id, sa.answerText
+        FROM SurveyAnswer sa
+        WHERE sa.feedback.id IN :feedbackIds
+        AND sa.question.id = 9
+    """)
+    List<Object[]> findOwnerMessagesByFeedbackIds(@Param("feedbackIds") List<Long> feedbackIds);
+
+    // 고객용 - 전체 답변 조회 (question 포함)
+    @Query("""
+        SELECT sa FROM SurveyAnswer sa
+        JOIN FETCH sa.question
+        WHERE sa.feedback.id = :feedbackId
+        ORDER BY sa.question.id
+    """)
+    List<SurveyAnswer> findByFeedbackIdWithQuestion(@Param("feedbackId") Long feedbackId);
 }

--- a/src/main/java/com/example/chalpuplatform/user/domain/User.java
+++ b/src/main/java/com/example/chalpuplatform/user/domain/User.java
@@ -53,9 +53,6 @@ public class User extends BaseTimeEntity {
     private Gender gender;
     
     private Integer age;
-    
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private UserProfile userProfile;
 
     public void updateOAuth2Info(String name, String picture) {
         this.name = name;

--- a/src/main/java/com/example/chalpuplatform/user/service/UserProfileService.java
+++ b/src/main/java/com/example/chalpuplatform/user/service/UserProfileService.java
@@ -51,9 +51,8 @@ public class UserProfileService {
     private UserProfile createNewUserProfile(Long userId) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new UserException(ErrorMessage.USER_NOT_FOUND));
-        
+
         UserProfile newProfile = UserProfile.create(user);
-        user.setUserProfile(newProfile);
         return userProfileRepository.save(newProfile);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -70,8 +70,10 @@ server:
 # OAuth2 Redirect URLs
 oauth2:
   redirect:
-    success-url: ${oauth2-redirect-success-url}
-    failure-url: ${oauth2-redirect-failure-url}
+    success-path: ${oauth2-redirect-success-path}
+    failure-path: ${oauth2-redirect-failure-path}
+    owner-domain: ${oauth2-owner-domain}
+    customer-domain: ${oauth2-customer-domain}
 
 cloud:
   aws:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -67,6 +67,14 @@ server:
   tomcat:
     use-relative-redirects: true
 
+# OAuth2 Redirect URLs
+oauth2:
+  redirect:
+    success-path: ${OAUTH2_REDIRECT_SUCCESS_PATH}
+    failure-path: ${OAUTH2_REDIRECT_FAILURE_PATH}
+    owner-domain: ${OAUTH2_OWNER_DOMAIN}
+    customer-domain: ${OAUTH2_CUSTOMER_DOMAIN}
+
 management:
   endpoints:
     web:
@@ -82,11 +90,6 @@ management:
       export:
         enabled: true
 
-# OAuth2 Redirect URLs
-oauth2:
-  redirect:
-    success-url: ${OAUTH2_REDIRECT_SUCCESS_URL}
-    failure-url: ${OAUTH2_REDIRECT_FAILURE_URL}
 
 fcm:
   service-account-key-json: ${FCM_SERVICE_ACCOUNT_KEY_JSON}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -48,8 +48,10 @@ module "parameter_store" {
   aws_secret_key             = var.aws_secret_key
   kakao_client_id           = var.kakao_client_id
   kakao_client_secret       = var.kakao_client_secret
-  oauth2_redirect_success_url = var.oauth2_redirect_success_url
-  oauth2_redirect_failure_url = var.oauth2_redirect_failure_url
+  oauth2_redirect_success_path = var.oauth2_redirect_success_path
+  oauth2_redirect_failure_path = var.oauth2_redirect_failure_path
+  oauth2_owner_domain       = var.oauth2_owner_domain
+  oauth2_customer_domain    = var.oauth2_customer_domain
   s3_bucket                  = var.s3_bucket
   cloudfront_domain          = var.cloudfront_domain
   sentry_dsn                 = var.sentry_dsn

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -109,16 +109,28 @@ variable "kakao_client_secret" {
   sensitive   = true
 }
 
-variable "oauth2_redirect_success_url" {
-  description = "OAuth2 redirect success URL"
+variable "oauth2_redirect_success_path" {
+  description = "OAuth2 redirect success path"
   type        = string
-  default     = "https://chalpu.com/login/success"
+  default     = "/oauth2/success"
 }
 
-variable "oauth2_redirect_failure_url" {
-  description = "OAuth2 redirect failure URL"
+variable "oauth2_redirect_failure_path" {
+  description = "OAuth2 redirect failure path"
   type        = string
-  default     = "https://chalpu.com/login/failure"
+  default     = "/oauth2/failure"
+}
+
+variable "oauth2_owner_domain" {
+  description = "OAuth2 owner domain"
+  type        = string
+  default     = "owner.chalpu.com"
+}
+
+variable "oauth2_customer_domain" {
+  description = "OAuth2 customer domain"
+  type        = string
+  default     = "customer.chalpu.com"
 }
 
 # S3 and CloudFront

--- a/terraform/modules/secret/parameter-store/main.tf
+++ b/terraform/modules/secret/parameter-store/main.tf
@@ -122,27 +122,51 @@ resource "aws_ssm_parameter" "kakao_client_secret" {
   }
 }
 
-# OAuth2 Redirect URLs
-resource "aws_ssm_parameter" "oauth2_redirect_success_url" {
-  name        = "/chalpu-platform/${var.environment}/oauth2-redirect-success-url"
-  description = "OAuth2 redirect success URL"
+# OAuth2 Redirect Configuration
+resource "aws_ssm_parameter" "oauth2_redirect_success_path" {
+  name        = "/chalpu-platform/${var.environment}/oauth2-redirect-success-path"
+  description = "OAuth2 redirect success path"
   type        = "String"
-  value       = var.oauth2_redirect_success_url
+  value       = var.oauth2_redirect_success_path
 
   tags = {
-    Name        = "chalpu-${var.environment}-oauth2-redirect-success-url"
+    Name        = "chalpu-${var.environment}-oauth2-redirect-success-path"
     Environment = var.environment
   }
 }
 
-resource "aws_ssm_parameter" "oauth2_redirect_failure_url" {
-  name        = "/chalpu-platform/${var.environment}/oauth2-redirect-failure-url"
-  description = "OAuth2 redirect failure URL"
+resource "aws_ssm_parameter" "oauth2_redirect_failure_path" {
+  name        = "/chalpu-platform/${var.environment}/oauth2-redirect-failure-path"
+  description = "OAuth2 redirect failure path"
   type        = "String"
-  value       = var.oauth2_redirect_failure_url
+  value       = var.oauth2_redirect_failure_path
 
   tags = {
-    Name        = "chalpu-${var.environment}-oauth2-redirect-failure-url"
+    Name        = "chalpu-${var.environment}-oauth2-redirect-failure-path"
+    Environment = var.environment
+  }
+}
+
+resource "aws_ssm_parameter" "oauth2_owner_domain" {
+  name        = "/chalpu-platform/${var.environment}/oauth2-owner-domain"
+  description = "OAuth2 owner domain"
+  type        = "String"
+  value       = var.oauth2_owner_domain
+
+  tags = {
+    Name        = "chalpu-${var.environment}-oauth2-owner-domain"
+    Environment = var.environment
+  }
+}
+
+resource "aws_ssm_parameter" "oauth2_customer_domain" {
+  name        = "/chalpu-platform/${var.environment}/oauth2-customer-domain"
+  description = "OAuth2 customer domain"
+  type        = "String"
+  value       = var.oauth2_customer_domain
+
+  tags = {
+    Name        = "chalpu-${var.environment}-oauth2-customer-domain"
     Environment = var.environment
   }
 }

--- a/terraform/modules/secret/parameter-store/variables.tf
+++ b/terraform/modules/secret/parameter-store/variables.tf
@@ -61,16 +61,28 @@ variable "kakao_client_secret" {
   sensitive   = true
 }
 
-variable "oauth2_redirect_success_url" {
-  description = "OAuth2 redirect success URL"
+variable "oauth2_redirect_success_path" {
+  description = "OAuth2 redirect success path"
   type        = string
-  default     = "https://chalpu.com/login/success"
+  default     = "/oauth2/success"
 }
 
-variable "oauth2_redirect_failure_url" {
-  description = "OAuth2 redirect failure URL"
+variable "oauth2_redirect_failure_path" {
+  description = "OAuth2 redirect failure path"
   type        = string
-  default     = "https://chalpu.com/login/failure"
+  default     = "/oauth2/failure"
+}
+
+variable "oauth2_owner_domain" {
+  description = "OAuth2 owner domain"
+  type        = string
+  default     = "owner.chalpu.com"
+}
+
+variable "oauth2_customer_domain" {
+  description = "OAuth2 customer domain"
+  type        = string
+  default     = "customer.chalpu.com"
 }
 
 variable "s3_bucket" {


### PR DESCRIPTION
- CustomAuthorizationRequestResolver에서 request.getServerName() 대신 Origin/Referer 헤더 사용
- OAuth2AuthenticationSuccessHandler에서 클라이언트 도메인 기반 리다이렉트 구현
- OAuth2AuthenticationFailureHandler에서 클라이언트 도메인 기반 리다이렉트 구현
- owner.chalpu.com과 customer.chalpu.com 도메인 구분 처리