### PR TITLE
refactor: 리팩토링에 따른 테스트 코드를 수정했습니다

### DIFF
--- a/OPTIMIZATION_PLAN.md
+++ b/OPTIMIZATION_PLAN.md
@@ -1,0 +1,598 @@
+# 최적화 및 리팩토링 계획
+
+## 📋 프로젝트 분석 결과
+
+프로젝트 코드베이스를 분석한 결과, 성능 최적화와 아키텍처 패턴 개선이 필요한 여러 영역을 발견했습니다.
+
+## 1. JPA 성능 최적화
+
+### 1.1 Fetch Join을 @EntityGraph로 변경
+
+**현재 상황**
+- CustomerFeedbackRepository, SurveyAnswerRepository 등에서 JOIN FETCH 사용
+- Hibernate가 Page + Fetch Join 조합에 대해 경고 메시지 출력 (실제 성능 문제는 없음)
+
+**개선 방안**
+```java
+// 현재 코드 (CustomerFeedbackRepository)
+@Query("""
+    SELECT cf FROM CustomerFeedback cf
+    LEFT JOIN FETCH cf.foodItem
+    LEFT JOIN FETCH cf.store
+    LEFT JOIN FETCH cf.user
+    LEFT JOIN FETCH cf.survey
+    WHERE cf.store.id = :storeId
+    AND cf.isActive = true
+""")
+Page<CustomerFeedback> findByStoreIdWithDetails(@Param("storeId") Long storeId, Pageable pageable);
+
+// 개선안: @EntityGraph 사용
+@EntityGraph(attributePaths = {"foodItem", "store", "user", "survey"})
+Page<CustomerFeedback> findByStoreIdAndIsActiveTrueOrderByCreatedAtDesc(Long storeId, Pageable pageable);
+```
+
+**변경 대상 Repository**
+1. CustomerFeedbackRepository - 3개 메서드
+2. SurveyAnswerRepository - 2개 메서드
+3. PhotoRepository - 페치 조인 확인 필요
+4. UserStoreRoleRepository - 페치 조인 확인 필요
+
+### 1.2 @OneToMany 관계 Batch Size 최적화
+
+**현재 상황**
+- Store.foodItems: @OneToMany 관계로 N+1 문제 발생 가능
+- Lazy Loading 시 각 Store마다 별도 쿼리 실행
+
+**개선 방안**
+```java
+// Store 엔티티
+@Entity
+@BatchSize(size = 25) // 클래스 레벨 배치 설정
+public class Store extends BaseTimeEntity {
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL)
+    @BatchSize(size = 50) // 컬렉션별 개별 설정
+    private List<FoodItem> foodItems = new ArrayList<>();
+}
+
+// application.yml 전역 설정
+spring:
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 20
+        jdbc.batch_size: 25
+```
+
+**최적화 대상**
+- Store.foodItems (현재 유일한 @OneToMany)
+- 향후 추가될 @OneToMany 관계들
+
+## 2. DDD (Domain-Driven Design) 패턴 적용
+
+### 2.1 Rich Domain Model로 전환
+
+**현재 문제점**
+- Anemic Domain Model (빈약한 도메인 모델)
+- 비즈니스 로직이 Service 계층에 분산되어 있음
+- 엔티티가 단순 데이터 컨테이너 역할만 수행
+
+**개선 방안**
+
+#### Value Objects 도입
+```java
+// Price Value Object
+public record Price(BigDecimal amount, String currency) {
+    public Price {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("가격은 음수일 수 없습니다");
+        }
+    }
+
+    public Price applyDiscount(BigDecimal discountRate) {
+        return new Price(amount.multiply(BigDecimal.ONE.subtract(discountRate)), currency);
+    }
+}
+
+// S3Key Value Object
+public record S3Key(String bucket, String key) {
+    public static S3Key generate(String bucket, String fileName) {
+        String uuid = UUID.randomUUID().toString();
+        return new S3Key(bucket, "photos/" + uuid + "/" + fileName);
+    }
+
+    public String getFullPath() {
+        return bucket + "/" + key;
+    }
+}
+
+// PhotoMetadata Value Object
+public record PhotoMetadata(Integer width, Integer height, Long fileSize) {
+    public boolean isValidDimensions() {
+        return width > 0 && height > 0 && fileSize > 0;
+    }
+}
+```
+
+#### Domain Service 도입
+```java
+// 도메인 서비스 - 여러 엔티티에 걸친 비즈니스 규칙
+@Service
+public class FoodItemDomainService {
+    public FoodItem createFoodItem(Store store, FoodItemCommand command) {
+        validateStoreCapacity(store);
+        validatePriceRange(command.getPrice());
+
+        FoodItem foodItem = FoodItem.builder()
+            .store(store)
+            .name(command.getName())
+            .price(new Price(command.getPrice(), "KRW"))
+            .build();
+
+        store.addFoodItem(foodItem);
+        return foodItem;
+    }
+
+    private void validateStoreCapacity(Store store) {
+        if (store.getFoodItems().size() >= 100) {
+            throw new DomainException("가게당 최대 100개 메뉴만 등록 가능합니다");
+        }
+    }
+}
+
+// 도메인 서비스 - 피드백 생성 로직
+@Service
+public class CustomerFeedbackDomainService {
+    public CustomerFeedback createFeedback(FeedbackCommand command) {
+        CustomerFeedback feedback = new CustomerFeedback();
+
+        // 도메인 규칙 적용
+        feedback.validateEligibility(command.getUser());
+        feedback.captureCustomerTasteSnapshot(command.getUserProfile());
+        feedback.calculateRewardPoints();
+
+        return feedback;
+    }
+}
+```
+
+#### Rich Domain Entity 구현
+```java
+@Entity
+public class Store extends BaseTimeEntity {
+    // 필드들...
+
+    // 비즈니스 메서드
+    public void addFoodItem(FoodItem foodItem) {
+        validateFoodItemAddition(foodItem);
+        this.foodItems.add(foodItem);
+        foodItem.setStore(this);
+    }
+
+    public void removeFoodItem(FoodItem foodItem) {
+        if (!foodItem.canBeDeleted()) {
+            throw new DomainException("진행중인 주문이 있는 메뉴는 삭제할 수 없습니다");
+        }
+        this.foodItems.remove(foodItem);
+    }
+
+    public void updateDeliveryLinks(DeliveryPlatformLinks links) {
+        validateDeliveryLinks(links);
+        this.deliveryPlatformLinks = links;
+    }
+
+    private void validateFoodItemAddition(FoodItem item) {
+        if (this.foodItems.size() >= 100) {
+            throw new DomainException("메뉴는 최대 100개까지만 등록 가능합니다");
+        }
+    }
+}
+
+@Entity
+public class FoodItem extends BaseTimeEntity {
+    private Price price; // Value Object 사용
+
+    public void updatePrice(Price newPrice) {
+        if (hasActivePromotion() && newPrice.isHigherThan(this.price)) {
+            throw new DomainException("프로모션 진행중에는 가격을 인상할 수 없습니다");
+        }
+        this.price = newPrice;
+    }
+
+    public boolean canBeDeleted() {
+        return !hasActiveOrders() && !hasActivePromotion();
+    }
+
+    public void applyPromotion(Promotion promotion) {
+        validatePromotion(promotion);
+        this.currentPromotion = promotion;
+        this.promotionPrice = this.price.applyDiscount(promotion.getDiscountRate());
+    }
+}
+```
+
+### 2.2 도메인 이벤트 도입
+
+**개선 방안**
+```java
+// 도메인 이벤트
+public record FeedbackCreatedEvent(
+    Long feedbackId,
+    Long userId,
+    Long storeId,
+    Integer rewardPoints
+) implements DomainEvent {}
+
+// 이벤트 발행
+@Entity
+public class CustomerFeedback extends BaseTimeEntity {
+    @DomainEvents
+    private List<DomainEvent> domainEvents = new ArrayList<>();
+
+    public static CustomerFeedback create(FeedbackCommand command) {
+        CustomerFeedback feedback = new CustomerFeedback();
+        // ... 생성 로직
+
+        // 이벤트 발행
+        feedback.domainEvents.add(new FeedbackCreatedEvent(
+            feedback.getId(),
+            command.getUserId(),
+            command.getStoreId(),
+            1
+        ));
+
+        return feedback;
+    }
+}
+
+// 이벤트 리스너
+@Component
+public class FeedbackEventHandler {
+    @EventListener
+    public void handleFeedbackCreated(FeedbackCreatedEvent event) {
+        // 리워드 포인트 지급
+        // 알림 발송
+        // 통계 업데이트
+    }
+}
+```
+
+## 3. CQRS (Command Query Responsibility Segregation) 패턴 적용
+
+### 3.1 서비스 레이어 명령/조회 분리
+
+**현재 문제점**
+- 하나의 서비스에 조회와 명령 로직이 혼재
+- 복잡한 조회 요구사항과 비즈니스 로직이 결합되어 있음
+- 성능 최적화가 어려움
+
+**적용 대상 서비스**
+1. CustomerFeedbackService - 가장 복잡한 서비스
+2. FoodItemService - 조회와 명령이 명확히 구분
+3. StoreService - 조회 빈도가 높음
+4. RewardService - 포인트 조회와 사용 분리 필요
+
+### 3.2 CustomerFeedback CQRS 구현
+
+#### Query Service (조회 전용)
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomerFeedbackQueryService {
+    private final CustomerFeedbackRepository repository;
+
+    // 사장님용 피드백 조회 (읽음 상태, 통계 포함)
+    public PageResponse<OwnerFeedbackView> getOwnerFeedbacks(Long storeId, Pageable pageable) {
+        // 최적화된 조회 쿼리
+        // Projection 사용으로 필요한 필드만 조회
+        return repository.findOwnerFeedbackViews(storeId, pageable);
+    }
+
+    // 고객용 피드백 히스토리
+    public PageResponse<CustomerFeedbackHistory> getCustomerHistory(Long userId, Pageable pageable) {
+        // 고객 관점의 간단한 조회
+        return repository.findCustomerHistory(userId, pageable);
+    }
+
+    // 통계 조회 (캐싱 적용)
+    @Cacheable(value = "feedbackStats", key = "#storeId")
+    public FeedbackStatistics getStatistics(Long storeId, Period period) {
+        return repository.calculateStatistics(storeId, period);
+    }
+
+    // 읽지 않은 피드백 개수
+    public UnreadCountResponse getUnreadCounts(Long storeId) {
+        return repository.getUnreadCountsByStore(storeId);
+    }
+}
+```
+
+#### Command Service (명령 처리)
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomerFeedbackCommandService {
+    private final CustomerFeedbackDomainService domainService;
+    private final CustomerFeedbackRepository repository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public CustomerFeedbackResponse createFeedback(CreateFeedbackCommand command) {
+        // 도메인 서비스를 통한 생성
+        CustomerFeedback feedback = domainService.createFeedback(command);
+
+        // 저장
+        CustomerFeedback saved = repository.save(feedback);
+
+        // 이벤트 발행
+        eventPublisher.publishEvent(new FeedbackCreatedEvent(saved));
+
+        return CustomerFeedbackResponse.from(saved);
+    }
+
+    public void markAsViewed(Long feedbackId, Long userId) {
+        CustomerFeedback feedback = repository.findById(feedbackId)
+            .orElseThrow(() -> new NotFoundException("피드백을 찾을 수 없습니다"));
+
+        feedback.markAsViewed(userId);
+        repository.save(feedback);
+    }
+
+    public void updateFeedbackStatus(Long feedbackId, FeedbackStatus status) {
+        CustomerFeedback feedback = repository.findById(feedbackId)
+            .orElseThrow(() -> new NotFoundException("피드백을 찾을 수 없습니다"));
+
+        feedback.updateStatus(status);
+        repository.save(feedback);
+
+        eventPublisher.publishEvent(new FeedbackStatusChangedEvent(feedbackId, status));
+    }
+}
+```
+
+#### Read Model (조회 전용 모델)
+```java
+// 사장님용 피드백 조회 모델
+public class OwnerFeedbackView {
+    private Long feedbackId;
+    private String customerName;
+    private String foodItemName;
+    private Integer rating;
+    private String comment;
+    private Boolean isViewed;
+    private LocalDateTime createdAt;
+    private List<SurveyAnswerSummary> surveyAnswers;
+    // Projection으로 DB에서 직접 조회
+}
+
+// 고객용 피드백 히스토리
+public class CustomerFeedbackHistory {
+    private Long feedbackId;
+    private String storeName;
+    private String foodItemName;
+    private Integer earnedPoints;
+    private LocalDateTime createdAt;
+    // 고객에게 필요한 정보만 포함
+}
+
+// 통계 모델
+public class FeedbackStatistics {
+    private Integer totalCount;
+    private Double averageRating;
+    private Map<Integer, Integer> ratingDistribution;
+    private List<TopFeedbackItem> topItems;
+    private TrendData trend;
+}
+```
+
+### 3.3 FoodItem CQRS 구현
+
+#### Query Service
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FoodItemQueryService {
+    private final FoodItemRepository repository;
+
+    // 고객용 메뉴 조회 (활성 메뉴만, 가격 정보 포함)
+    public PageResponse<FoodItemMenuView> getMenuForCustomers(Long storeId, Pageable pageable) {
+        return repository.findActiveMenuItems(storeId, pageable);
+    }
+
+    // 사장님용 메뉴 관리 조회 (모든 상태, 통계 포함)
+    public PageResponse<FoodItemManagementView> getMenuForManagement(Long storeId, Pageable pageable) {
+        return repository.findManagementView(storeId, pageable);
+    }
+
+    // 메뉴 검색
+    @Cacheable(value = "foodSearch", key = "#criteria.hashCode()")
+    public List<FoodItemSearchResult> searchFoodItems(SearchCriteria criteria) {
+        return repository.searchWithCriteria(criteria);
+    }
+
+    // 베스트 메뉴
+    public List<BestFoodItem> getBestItems(Long storeId, int limit) {
+        return repository.findBestItems(storeId, limit);
+    }
+}
+```
+
+#### Command Service
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FoodItemCommandService {
+    private final FoodItemDomainService domainService;
+    private final FoodItemRepository repository;
+    private final StoreRepository storeRepository;
+
+    public FoodItemResponse createFoodItem(CreateFoodItemCommand command) {
+        Store store = storeRepository.findById(command.getStoreId())
+            .orElseThrow(() -> new NotFoundException("가게를 찾을 수 없습니다"));
+
+        // 도메인 서비스를 통한 생성
+        FoodItem foodItem = domainService.createFoodItem(store, command);
+
+        FoodItem saved = repository.save(foodItem);
+        return FoodItemResponse.from(saved);
+    }
+
+    public void updateFoodItem(UpdateFoodItemCommand command) {
+        FoodItem foodItem = repository.findById(command.getFoodItemId())
+            .orElseThrow(() -> new NotFoundException("메뉴를 찾을 수 없습니다"));
+
+        // 도메인 로직 수행
+        foodItem.update(command);
+        repository.save(foodItem);
+    }
+
+    public void deleteFoodItem(Long foodItemId, Long userId) {
+        FoodItem foodItem = repository.findById(foodItemId)
+            .orElseThrow(() -> new NotFoundException("메뉴를 찾을 수 없습니다"));
+
+        // 도메인 규칙 검증
+        if (!foodItem.canBeDeleted()) {
+            throw new BusinessException("삭제할 수 없는 메뉴입니다");
+        }
+
+        foodItem.softDelete();
+        repository.save(foodItem);
+    }
+}
+```
+
+### 3.4 Repository 레벨 CQRS
+
+#### Query Repository
+```java
+@Repository
+public interface CustomerFeedbackQueryRepository {
+    // Projection 기반 조회
+    @Query("""
+        SELECT new com.example.dto.OwnerFeedbackView(
+            cf.id, u.name, fi.foodName, cf.rating, cf.comment, cf.isViewed, cf.createdAt
+        )
+        FROM CustomerFeedback cf
+        JOIN cf.user u
+        JOIN cf.foodItem fi
+        WHERE cf.store.id = :storeId
+        ORDER BY cf.createdAt DESC
+    """)
+    Page<OwnerFeedbackView> findOwnerFeedbackViews(@Param("storeId") Long storeId, Pageable pageable);
+
+    // Native Query for 복잡한 통계
+    @Query(nativeQuery = true, value = """
+        SELECT
+            COUNT(*) as total_count,
+            AVG(rating) as avg_rating,
+            COUNT(CASE WHEN is_viewed = false THEN 1 END) as unread_count
+        FROM customer_feedback
+        WHERE store_id = :storeId
+        AND created_at >= :startDate
+    """)
+    FeedbackStatistics calculateStatistics(@Param("storeId") Long storeId, @Param("startDate") LocalDateTime startDate);
+}
+```
+
+#### Command Repository
+```java
+@Repository
+public interface CustomerFeedbackCommandRepository extends JpaRepository<CustomerFeedback, Long> {
+    // 단순 CRUD 작업만 수행
+    // 복잡한 조회는 QueryRepository로 분리
+}
+```
+
+## 4. 기타 코드 개선사항
+
+### 4.1 엔티티 @Data 어노테이션 제거
+
+**현재 문제점**
+- JPA 엔티티에 @Data 사용은 안티패턴 (equals/hashCode 문제, 양방향 연관관계 순환참조)
+
+**개선 방안**
+```java
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Store extends BaseTimeEntity {
+    // @Setter는 필요한 필드에만 선택적으로 적용
+}
+```
+
+### 4.2 트랜잭션 범위 최적화
+
+**개선 방안**
+```java
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+    // 클래스 레벨 @Transactional 제거
+
+    @Transactional(readOnly = true)
+    public StoreResponse getStore(Long storeId) {
+        // 조회 로직
+    }
+
+    @Transactional
+    public StoreResponse createStore(StoreRequest request) {
+        // 생성 로직
+    }
+}
+```
+
+### 4.3 벌크 연산 최적화
+
+**개선 방안**
+```java
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    @Modifying
+    @Query("UPDATE Photo p SET p.isActive = false WHERE p.foodItem.id IN :foodItemIds")
+    void softDeleteByFoodItemIds(@Param("foodItemIds") List<Long> foodItemIds);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Photo p WHERE p.createdAt < :date AND p.isTemporary = true")
+    void deleteOldTemporaryPhotos(@Param("date") LocalDateTime date);
+}
+```
+
+## 5. 구현 우선순위
+
+### Phase 1: 성능 최적화 (1-2주)
+1. N+1 문제 해결
+2. 페치 조인 최적화
+3. 벌크 연산 구현
+
+### Phase 2: DDD 패턴 적용 (2-3주)
+1. Value Objects 도입
+2. Rich Domain Model 전환
+3. Domain Service 계층 추가
+
+### Phase 3: CQRS 패턴 적용 (2-3주)
+1. 핵심 서비스부터 단계적 분리
+2. Read Model 구현
+3. 이벤트 소싱 고려 (선택사항)
+
+### Phase 4: 코드 품질 개선 (1주)
+1. 엔티티 어노테이션 정리
+2. 트랜잭션 최적화
+3. 테스트 코드 보강
+
+## 6. 예상 효과
+
+- **성능 향상**: 쿼리 최적화로 30-50% 응답시간 단축 예상
+- **유지보수성**: 명확한 책임 분리로 코드 이해도 향상
+- **확장성**: DDD와 CQRS 패턴으로 비즈니스 로직 확장 용이
+- **테스트 용이성**: 도메인 로직 분리로 단위 테스트 작성 간소화
+
+## 7. 주의사항
+
+- 단계적 적용으로 리스크 최소화
+- 각 단계별 성능 측정 및 모니터링
+- 기존 API 호환성 유지
+- 충분한 테스트 코드 작성 후 리팩토링 진행

--- a/src/main/java/com/example/chalpuplatform/campaign/controller/CampaignController.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/controller/CampaignController.java
@@ -18,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -110,48 +109,17 @@ public class CampaignController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @GetMapping("/store/{storeId}")
-    @Operation(summary = "매장별 캠페인 목록 조회", description = "특정 매장의 캠페인 목록을 페이징하여 조회합니다")
+    @PostMapping("/store/list")
+    @Operation(summary = "매장별 캠페인 목록 조회", description = "특정 매장의 캠페인 목록을 페이징하여 조회합니다. 상태로 필터링 가능")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "캠페인 목록 조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "매장을 찾을 수 없음")
     })
     public ResponseEntity<ApiResponse<PageResponse<CampaignResponse>>> getCampaignsByStore(
-        @PathVariable("storeId") Long storeId,
+        @Valid @RequestBody GetCampaignsByStoreRequest request,
         @PageableDefault(size = 20) Pageable pageable
     ) {
-        PageResponse<CampaignResponse> response = campaignQueryService.getCampaignsByStore(storeId, pageable);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    @GetMapping("/store/{storeId}/active")
-    @Operation(summary = "매장의 활성 캠페인 조회", description = "특정 매장의 활성 상태 캠페인만 조회합니다")
-    public ResponseEntity<ApiResponse<List<CampaignResponse>>> getActiveCampaignsByStore(
-        @PathVariable("storeId") Long storeId
-    ) {
-        List<CampaignResponse> response = campaignQueryService.getActiveCampaignsByStore(storeId);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    @GetMapping("/{id}/statistics")
-    @Operation(summary = "캠페인 통계 조회", description = "캠페인의 상세 통계 정보를 조회합니다")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "통계 조회 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "캠페인을 찾을 수 없음")
-    })
-    public ResponseEntity<ApiResponse<CampaignStatisticsResponse>> getCampaignStatistics(
-        @PathVariable("id") Long campaignId
-    ) {
-        CampaignStatisticsResponse response = campaignQueryService.getCampaignStatistics(campaignId);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    @GetMapping("/store/{storeId}/dashboard")
-    @Operation(summary = "매장 캠페인 대시보드", description = "매장의 캠페인 대시보드 데이터를 조회합니다")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> getCampaignDashboard(
-        @PathVariable("storeId") Long storeId
-    ) {
-        Map<String, Object> response = campaignQueryService.getDashboardData(storeId);
+        PageResponse<CampaignResponse> response = campaignQueryService.getCampaignsByStore(request, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/example/chalpuplatform/campaign/domain/Campaign.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/domain/Campaign.java
@@ -126,13 +126,6 @@ public class Campaign extends BaseTimeEntity {
         this.endDate = endDate;
     }
 
-    public double calculateProgressRate(long currentFeedbackCount) {
-        if (this.targetFeedbackCount == null || this.targetFeedbackCount == 0) {
-            return 0.0;
-        }
-        return Math.min(100.0, (double) currentFeedbackCount / this.targetFeedbackCount * 100);
-    }
-
     public boolean isTargetReached(long currentFeedbackCount) {
         return currentFeedbackCount >= this.targetFeedbackCount;
     }

--- a/src/main/java/com/example/chalpuplatform/campaign/dto/CampaignDetailResponse.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/dto/CampaignDetailResponse.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Data
 @NoArgsConstructor
@@ -44,14 +45,14 @@ public class CampaignDetailResponse {
     @Schema(description = "현재 피드백 수", example = "45")
     private Long currentFeedbackCount;
 
-    @Schema(description = "진행률 (%)", example = "45.0")
-    private Double progressRate;
-
     @Schema(description = "캠페인 상태", example = "활성")
     private String status;
 
     @Schema(description = "활성 여부", example = "true")
     private Boolean isActive;
+
+    @Schema(description = "캠페인 진행 일수", example = "10")
+    private Integer targetDays;
 
     @Schema(description = "캠페인 시작일", example = "2024-01-01 00:00:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
@@ -61,15 +62,9 @@ public class CampaignDetailResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime endDate;
 
-    @Schema(description = "생성일시", example = "2024-01-01 00:00:00")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime createdAt;
-
-    @Schema(description = "수정일시", example = "2024-01-01 00:00:00")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime updatedAt;
-
     public static CampaignDetailResponse from(Campaign campaign, long currentFeedbackCount) {
+        int targetDays = (int) ChronoUnit.DAYS.between(campaign.getStartDate(), campaign.getEndDate()) + 1;
+
         return CampaignDetailResponse.builder()
             .id(campaign.getId())
             .name(campaign.getName())
@@ -80,13 +75,11 @@ public class CampaignDetailResponse {
             .foodItemName(campaign.getFoodItem().getFoodName())
             .targetFeedbackCount(campaign.getTargetFeedbackCount())
             .currentFeedbackCount(currentFeedbackCount)
-            .progressRate(campaign.calculateProgressRate(currentFeedbackCount))
             .status(campaign.getStatus().getKorean())
             .isActive(campaign.isActive())
+            .targetDays(targetDays)
             .startDate(campaign.getStartDate())
             .endDate(campaign.getEndDate())
-            .createdAt(campaign.getCreatedAt())
-            .updatedAt(campaign.getUpdatedAt())
             .build();
     }
 }

--- a/src/main/java/com/example/chalpuplatform/campaign/dto/CampaignResponse.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/dto/CampaignResponse.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Data
 @NoArgsConstructor
@@ -44,6 +45,9 @@ public class CampaignResponse {
     @Schema(description = "캠페인 상태", example = "활성")
     private String status;
 
+    @Schema(description = "캠페인 진행 일수", example = "10")
+    private Integer targetDays;
+
     @Schema(description = "캠페인 시작일", example = "2024-01-01 00:00:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime startDate;
@@ -61,6 +65,8 @@ public class CampaignResponse {
     private LocalDateTime updatedAt;
 
     public static CampaignResponse from(Campaign campaign) {
+        int targetDays = (int) ChronoUnit.DAYS.between(campaign.getStartDate(), campaign.getEndDate()) + 1;
+
         return CampaignResponse.builder()
             .id(campaign.getId())
             .name(campaign.getName())
@@ -71,6 +77,7 @@ public class CampaignResponse {
             .foodItemName(campaign.getFoodItem().getFoodName())
             .targetFeedbackCount(campaign.getTargetFeedbackCount())
             .status(campaign.getStatus().getKorean())
+            .targetDays(targetDays)
             .startDate(campaign.getStartDate())
             .endDate(campaign.getEndDate())
             .createdAt(campaign.getCreatedAt())

--- a/src/main/java/com/example/chalpuplatform/campaign/dto/CampaignStatisticsResponse.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/dto/CampaignStatisticsResponse.java
@@ -28,9 +28,6 @@ public class CampaignStatisticsResponse {
     @Schema(description = "총 피드백 수", example = "45")
     private Long totalFeedbackCount;
 
-    @Schema(description = "진행률 (%)", example = "45.0")
-    private Double progressRate;
-
     @Schema(description = "평균 만족도", example = "4.5")
     private Double averageSatisfaction;
 

--- a/src/main/java/com/example/chalpuplatform/campaign/dto/CreateCampaignRequest.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/dto/CreateCampaignRequest.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -40,12 +38,8 @@ public class CreateCampaignRequest {
     private Integer targetFeedbackCount;
 
     @NotNull
-    @FutureOrPresent
-    @Schema(description = "캠페인 시작일", example = "2024-01-01T00:00:00", required = true)
-    private LocalDateTime startDate;
-
-    @NotNull
-    @Future
-    @Schema(description = "캠페인 종료일", example = "2024-12-31T23:59:59", required = true)
-    private LocalDateTime endDate;
+    @Min(1)
+    @Max(365)
+    @Schema(description = "캠페인 진행 일수", example = "10", required = true)
+    private Integer targetDays;
 }

--- a/src/main/java/com/example/chalpuplatform/campaign/dto/CreateCampaignRequest.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/dto/CreateCampaignRequest.java
@@ -35,8 +35,8 @@ public class CreateCampaignRequest {
 
     @NotNull
     @Min(1)
-    @Max(10000)
-    @Schema(description = "목표 피드백 수", example = "100", required = true)
+    @Max(100)
+    @Schema(description = "목표 피드백 수", example = "50", required = true)
     private Integer targetFeedbackCount;
 
     @NotNull

--- a/src/main/java/com/example/chalpuplatform/campaign/dto/GetCampaignsByStoreRequest.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/dto/GetCampaignsByStoreRequest.java
@@ -1,0 +1,24 @@
+package com.example.chalpuplatform.campaign.dto;
+
+import com.example.chalpuplatform.campaign.domain.Campaign;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "매장별 캠페인 조회 요청")
+public class GetCampaignsByStoreRequest {
+
+    @NotNull
+    @Schema(description = "매장 ID", example = "1", required = true)
+    private Long storeId;
+
+    @Schema(description = "캠페인 상태 필터 (선택, null이면 모든 상태)", example = "ACTIVE")
+    private Campaign.CampaignStatus status;
+}

--- a/src/main/java/com/example/chalpuplatform/campaign/dto/UpdateCampaignRequest.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/dto/UpdateCampaignRequest.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,10 +37,8 @@ public class UpdateCampaignRequest {
     private Long storeId;
 
     @NotNull
-    @Schema(description = "캠페인 시작일", example = "2024-01-01T00:00:00", required = true)
-    private LocalDateTime startDate;
-
-    @NotNull
-    @Schema(description = "캠페인 종료일", example = "2024-12-31T23:59:59", required = true)
-    private LocalDateTime endDate;
+    @Min(1)
+    @Max(365)
+    @Schema(description = "캠페인 진행 일수", example = "10", required = true)
+    private Integer targetDays;
 }

--- a/src/main/java/com/example/chalpuplatform/campaign/repository/CampaignRepository.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/repository/CampaignRepository.java
@@ -20,8 +20,8 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long> {
     // 매장별 캠페인 조회
     Page<Campaign> findByStoreAndIsActiveTrue(Store store, Pageable pageable);
 
-    // 매장의 특정 상태 캠페인 조회
-    List<Campaign> findByStoreAndStatusAndIsActiveTrue(Store store, Campaign.CampaignStatus status);
+    // 매장의 특정 상태 캠페인 조회 (페이징)
+    Page<Campaign> findByStoreAndStatusAndIsActiveTrue(Store store, Campaign.CampaignStatus status, Pageable pageable);
 
     // 특정 음식의 활성 캠페인 조회
     @Query("SELECT c FROM Campaign c " +

--- a/src/main/java/com/example/chalpuplatform/campaign/service/CampaignCommandService.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/service/CampaignCommandService.java
@@ -19,6 +19,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -63,7 +67,15 @@ public class CampaignCommandService {
 
         // 도메인 검증
         campaignDomainService.validateTargetFeedbackCount(request.getTargetFeedbackCount());
-        campaignDomainService.validateCampaignCreation(foodItem, request.getStartDate(), request.getEndDate());
+        campaignDomainService.validateTargetDays(request.getTargetDays());
+
+        // 한국 시간 기준으로 날짜 계산
+        ZonedDateTime koreanNow = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime startDate = koreanNow.toLocalDate().atStartOfDay();
+        LocalDateTime endDate = startDate.plusDays(request.getTargetDays() - 1).withHour(23).withMinute(59).withSecond(59);
+
+        // 도메인 검증 (날짜 계산 후 검증)
+        campaignDomainService.validateCampaignCreation(foodItem, startDate, endDate);
 
         // 캠페인 생성
         Campaign campaign = Campaign.builder()
@@ -72,9 +84,9 @@ public class CampaignCommandService {
             .store(store)
             .foodItem(foodItem)
             .targetFeedbackCount(request.getTargetFeedbackCount())
-            .startDate(request.getStartDate())
-            .endDate(request.getEndDate())
-            .status(Campaign.CampaignStatus.DRAFT)
+            .startDate(startDate)
+            .endDate(endDate)
+            .status(Campaign.CampaignStatus.ACTIVE)
             .build();
 
         Campaign savedCampaign = campaignRepository.save(campaign);
@@ -102,15 +114,20 @@ public class CampaignCommandService {
 
         // 도메인 검증
         campaignDomainService.validateTargetFeedbackCount(request.getTargetFeedbackCount());
-        campaignDomainService.validateCampaignUpdate(campaign, request.getStartDate(), request.getEndDate());
+        campaignDomainService.validateTargetDays(request.getTargetDays());
+
+        // 새로운 종료일 계산
+        LocalDateTime newEndDate = campaign.getStartDate().plusDays(request.getTargetDays() - 1).withHour(23).withMinute(59).withSecond(59);
+
+        campaignDomainService.validateCampaignUpdate(campaign, campaign.getStartDate(), newEndDate);
 
         // 업데이트
         campaign.updateCampaign(
             request.getName(),
             request.getDescription(),
             request.getTargetFeedbackCount(),
-            request.getStartDate(),
-            request.getEndDate()
+            campaign.getStartDate(), // 시작일은 변경 불가
+            newEndDate
         );
 
         campaignRepository.save(campaign);

--- a/src/main/java/com/example/chalpuplatform/campaign/service/CampaignCommandService.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/service/CampaignCommandService.java
@@ -47,9 +47,14 @@ public class CampaignCommandService {
         UserStoreRole usr = userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(userId, request.getStoreId())
             .orElseThrow(() -> new CampaignException(ErrorMessage.STORE_ACCESS_DENIED));
 
+        // 캠페인 관리 권한 확인
+        if (!usr.canManageStore()) {
+            throw new CampaignException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
+
         // 음식 확인
         FoodItem foodItem = foodItemRepository.findById(request.getFoodItemId())
-            .orElseThrow(() -> new CampaignException(ErrorMessage.FOOD_ITEM_NOT_FOUND));
+            .orElseThrow(() -> new CampaignException(ErrorMessage.FOODITEM_NOT_FOUND));
 
         // 음식이 해당 매장의 것인지 확인
         if (!foodItem.getStore().getId().equals(store.getId())) {
@@ -90,6 +95,11 @@ public class CampaignCommandService {
         UserStoreRole usr = userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(userId, request.getStoreId())
                 .orElseThrow(() -> new CampaignException(ErrorMessage.STORE_ACCESS_DENIED));
 
+        // 캠페인 관리 권한 확인
+        if (!usr.canManageStore()) {
+            throw new CampaignException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
+
         // 도메인 검증
         campaignDomainService.validateTargetFeedbackCount(request.getTargetFeedbackCount());
         campaignDomainService.validateCampaignUpdate(campaign, request.getStartDate(), request.getEndDate());
@@ -120,6 +130,11 @@ public class CampaignCommandService {
         UserStoreRole usr = userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(userId, campaign.getStore().getId())
             .orElseThrow(() -> new CampaignException(ErrorMessage.STORE_ACCESS_DENIED));
 
+        // 캠페인 관리 권한 확인
+        if (!usr.canManageStore()) {
+            throw new CampaignException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
+
         // 활성 캠페인은 삭제 불가
         if (campaign.getStatus() == Campaign.CampaignStatus.ACTIVE) {
             throw new IllegalStateException("활성 상태의 캠페인은 삭제할 수 없습니다");
@@ -144,6 +159,11 @@ public class CampaignCommandService {
         // UserStoreRole로 권한 확인
         UserStoreRole usr = userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(userId, campaign.getStore().getId())
             .orElseThrow(() -> new CampaignException(ErrorMessage.STORE_ACCESS_DENIED));
+
+        // 캠페인 관리 권한 확인
+        if (!usr.canManageStore()) {
+            throw new CampaignException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
 
         // 상태 변경
         switch (newStatus) {

--- a/src/main/java/com/example/chalpuplatform/campaign/service/CampaignDomainService.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/service/CampaignDomainService.java
@@ -17,6 +17,8 @@ public class CampaignDomainService {
     private static final int MIN_TARGET_FEEDBACK_COUNT = 1;
     private static final int MAX_TARGET_FEEDBACK_COUNT = 100;
     private static final long DEFAULT_CAMPAIGN_ID = 0L;
+    private static final int MIN_TARGET_DAYS = 1;
+    private static final int MAX_TARGET_DAYS = 365;
 
     private final CampaignRepository campaignRepository;
 
@@ -87,6 +89,16 @@ public class CampaignDomainService {
 
         if (targetCount > MAX_TARGET_FEEDBACK_COUNT) {
             throw new IllegalArgumentException("목표 피드백 수는 " + MAX_TARGET_FEEDBACK_COUNT + "개를 초과할 수 없습니다");
+        }
+    }
+
+    public void validateTargetDays(Integer targetDays) {
+        if (targetDays == null || targetDays < MIN_TARGET_DAYS) {
+            throw new IllegalArgumentException("캠페인 기간은 " + MIN_TARGET_DAYS + "일 이상이어야 합니다");
+        }
+
+        if (targetDays > MAX_TARGET_DAYS) {
+            throw new IllegalArgumentException("캠페인 기간은 " + MAX_TARGET_DAYS + "일을 초과할 수 없습니다");
         }
     }
 }

--- a/src/main/java/com/example/chalpuplatform/campaign/service/CampaignQueryService.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/service/CampaignQueryService.java
@@ -4,6 +4,7 @@ import com.example.chalpuplatform.campaign.domain.Campaign;
 import com.example.chalpuplatform.campaign.dto.CampaignDetailResponse;
 import com.example.chalpuplatform.campaign.dto.CampaignResponse;
 import com.example.chalpuplatform.campaign.dto.CampaignStatisticsResponse;
+import com.example.chalpuplatform.campaign.dto.GetCampaignsByStoreRequest;
 import com.example.chalpuplatform.campaign.repository.CampaignRepository;
 import com.example.chalpuplatform.common.response.PageResponse;
 import com.example.chalpuplatform.common.exception.CampaignException;
@@ -51,28 +52,23 @@ public class CampaignQueryService {
         return CampaignDetailResponse.from(campaign, currentFeedbackCount);
     }
 
-    public PageResponse<CampaignResponse> getCampaignsByStore(Long storeId, Pageable pageable) {
-        Store store = storeRepository.findById(storeId)
+    public PageResponse<CampaignResponse> getCampaignsByStore(GetCampaignsByStoreRequest request, Pageable pageable) {
+        Store store = storeRepository.findById(request.getStoreId())
             .orElseThrow(() -> new CampaignException(ErrorMessage.STORE_NOT_FOUND));
 
-        Page<Campaign> campaigns = campaignRepository.findByStoreAndIsActiveTrue(store, pageable);
+        Page<Campaign> campaigns;
+
+        if (request.getStatus() != null) {
+            // 상태가 지정된 경우 필터링
+            campaigns = campaignRepository.findByStoreAndStatusAndIsActiveTrue(store, request.getStatus(), pageable);
+        } else {
+            // 상태가 지정되지 않은 경우 모든 활성 캠페인
+            campaigns = campaignRepository.findByStoreAndIsActiveTrue(store, pageable);
+        }
 
         Page<CampaignResponse> campaignResponses = campaigns.map(CampaignResponse::from);
 
         return PageResponse.from(campaignResponses);
-    }
-
-    public List<CampaignResponse> getActiveCampaignsByStore(Long storeId) {
-        Store store = storeRepository.findById(storeId)
-            .orElseThrow(() -> new CampaignException(ErrorMessage.STORE_NOT_FOUND));
-
-        List<Campaign> activeCampaigns = campaignRepository.findActiveCampaignsByStore(
-            store, LocalDateTime.now()
-        );
-
-        return activeCampaigns.stream()
-            .map(CampaignResponse::from)
-            .collect(Collectors.toList());
     }
 
     public CampaignDetailResponse getCampaignWithProgress(Long campaignId) {
@@ -137,7 +133,6 @@ public class CampaignQueryService {
             .campaignName(campaign.getName())
             .targetFeedbackCount(campaign.getTargetFeedbackCount())
             .totalFeedbackCount(totalFeedbackCount)
-            .progressRate(campaign.calculateProgressRate(totalFeedbackCount))
             .averageSatisfaction(averageSatisfaction)
             .daysRemaining(daysRemaining)
             .totalDays(totalDays)
@@ -145,39 +140,6 @@ public class CampaignQueryService {
             .build();
     }
 
-    public Map<String, Object> getDashboardData(Long storeId) {
-        Store store = storeRepository.findById(storeId)
-            .orElseThrow(() -> new CampaignException(ErrorMessage.STORE_NOT_FOUND));
-
-        // 활성 캠페인 목록
-        List<Campaign> activeCampaigns = campaignRepository.findActiveCampaignsByStore(
-            store, LocalDateTime.now()
-        );
-
-        // 각 캠페인의 진행 상황
-        List<Map<String, Object>> campaignProgress = new ArrayList<>();
-        for (Campaign campaign : activeCampaigns) {
-            long currentCount = getCurrentFeedbackCount(campaign);
-            Map<String, Object> progress = new HashMap<>();
-            progress.put("campaignId", campaign.getId());
-            progress.put("campaignName", campaign.getName());
-            progress.put("foodItemName", campaign.getFoodItem().getFoodName());
-            progress.put("targetCount", campaign.getTargetFeedbackCount());
-            progress.put("currentCount", currentCount);
-            progress.put("progressRate", campaign.calculateProgressRate(currentCount));
-            progress.put("status", campaign.getStatus().getKorean());
-            progress.put("daysRemaining", ChronoUnit.DAYS.between(LocalDateTime.now(), campaign.getEndDate()));
-            campaignProgress.add(progress);
-        }
-
-        // 전체 통계
-        Map<String, Object> dashboard = new HashMap<>();
-        dashboard.put("activeCampaignCount", activeCampaigns.size());
-        dashboard.put("campaigns", campaignProgress);
-        dashboard.put("lastUpdated", LocalDateTime.now());
-
-        return dashboard;
-    }
 
     private long getCurrentFeedbackCount(Campaign campaign) {
         return customerFeedbackRepository.countByFoodItemAndStoreBetweenDates(

--- a/src/main/java/com/example/chalpuplatform/campaign/service/CampaignQueryService.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/service/CampaignQueryService.java
@@ -35,6 +35,7 @@ public class CampaignQueryService {
     private final StoreRepository storeRepository;
     private final CampaignDomainService campaignDomainService;
 
+    @Transactional
     public CampaignDetailResponse getCampaignById(Long campaignId) {
         Campaign campaign = campaignRepository.findById(campaignId)
             .orElseThrow(() -> new CampaignException(ErrorMessage.CAMPAIGN_NOT_FOUND));

--- a/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
@@ -107,8 +107,6 @@ public enum ErrorMessage {
     CAMPAIGN_OVERLAPPING(BAD_REQUEST, "해당 기간에 이미 진행 중인 캠페인이 있습니다."),
     CAMPAIGN_INVALID_DATE_RANGE(BAD_REQUEST, "잘못된 캠페인 기간입니다."),
     CAMPAIGN_TARGET_EXCEEDED(BAD_REQUEST, "목표 피드백 수가 제한을 초과했습니다."),
-    FOOD_ITEM_NOT_FOUND(NOT_FOUND, "음식 아이템을 찾을 수 없습니다."),
-    UNAUTHORIZED_ACCESS(FORBIDDEN, "접근 권한이 없습니다."),
 
     // 알림 관련 에러
     NOTIFICATION_SERVICE_UNAVAILABLE(HttpStatus.INTERNAL_SERVER_ERROR, "알림 서비스를 사용할 수 없습니다."),

--- a/src/test/java/com/example/chalpuplatform/campaign/service/CampaignCommandServiceTest.java
+++ b/src/test/java/com/example/chalpuplatform/campaign/service/CampaignCommandServiceTest.java
@@ -119,8 +119,7 @@ class CampaignCommandServiceTest {
                 .storeId(1L)
                 .foodItemId(1L)
                 .targetFeedbackCount(50)
-                .startDate(LocalDateTime.now().plusDays(1))
-                .endDate(LocalDateTime.now().plusDays(30))
+                .targetDays(30)
                 .build();
         }
 
@@ -285,11 +284,12 @@ class CampaignCommandServiceTest {
         @BeforeEach
         void setUp() {
             request = UpdateCampaignRequest.builder()
+                .campaignId(1L)
                 .name("수정된 캠페인")
                 .description("수정된 설명")
                 .targetFeedbackCount(100)
-                .startDate(LocalDateTime.now().plusDays(2))
-                .endDate(LocalDateTime.now().plusDays(60))
+                .targetDays(60)
+                .storeId(1L)
                 .build();
         }
 

--- a/src/test/java/com/example/chalpuplatform/campaign/service/CampaignQueryServiceTest.java
+++ b/src/test/java/com/example/chalpuplatform/campaign/service/CampaignQueryServiceTest.java
@@ -4,6 +4,7 @@ import com.example.chalpuplatform.campaign.domain.Campaign;
 import com.example.chalpuplatform.campaign.dto.CampaignDetailResponse;
 import com.example.chalpuplatform.campaign.dto.CampaignResponse;
 import com.example.chalpuplatform.campaign.dto.CampaignStatisticsResponse;
+import com.example.chalpuplatform.campaign.dto.GetCampaignsByStoreRequest;
 import com.example.chalpuplatform.campaign.repository.CampaignRepository;
 import com.example.chalpuplatform.common.exception.CampaignException;
 import com.example.chalpuplatform.common.exception.ErrorMessage;
@@ -142,7 +143,6 @@ class CampaignQueryServiceTest {
             assertThat(response.getName()).isEqualTo("테스트 캠페인");
             assertThat(response.getCurrentFeedbackCount()).isEqualTo(75L);
             assertThat(response.getTargetFeedbackCount()).isEqualTo(100);
-            assertThat(response.getProgressRate()).isEqualTo(75.0);
             assertThat(response.getIsActive()).isTrue();
 
             verify(customerFeedbackRepository).countByFoodItemAndStoreBetweenDates(
@@ -168,7 +168,6 @@ class CampaignQueryServiceTest {
 
             // then
             assertThat(response.getCurrentFeedbackCount()).isEqualTo(100L);
-            assertThat(response.getProgressRate()).isEqualTo(100.0);
 
             verify(campaignRepository).save(campaign);
             assertThat(campaign.getStatus()).isEqualTo(Campaign.CampaignStatus.COMPLETED);
@@ -208,7 +207,10 @@ class CampaignQueryServiceTest {
                 .willReturn(campaignPage);
 
             // when
-            PageResponse<CampaignResponse> response = campaignQueryService.getCampaignsByStore(1L, pageable);
+            GetCampaignsByStoreRequest request = GetCampaignsByStoreRequest.builder()
+                .storeId(1L)
+                .build();
+            PageResponse<CampaignResponse> response = campaignQueryService.getCampaignsByStore(request, pageable);
 
             // then
             assertThat(response).isNotNull();
@@ -230,7 +232,10 @@ class CampaignQueryServiceTest {
             given(storeRepository.findById(999L)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> campaignQueryService.getCampaignsByStore(999L, pageable))
+            GetCampaignsByStoreRequest request = GetCampaignsByStoreRequest.builder()
+                .storeId(999L)
+                .build();
+            assertThatThrownBy(() -> campaignQueryService.getCampaignsByStore(request, pageable))
                 .isInstanceOf(CampaignException.class)
                 .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOT_FOUND);
 
@@ -249,53 +254,43 @@ class CampaignQueryServiceTest {
                 .willReturn(emptyPage);
 
             // when
-            PageResponse<CampaignResponse> response = campaignQueryService.getCampaignsByStore(1L, pageable);
+            GetCampaignsByStoreRequest request = GetCampaignsByStoreRequest.builder()
+                .storeId(1L)
+                .build();
+            PageResponse<CampaignResponse> response = campaignQueryService.getCampaignsByStore(request, pageable);
 
             // then
             assertThat(response.getContent()).isEmpty();
             assertThat(response.getTotalElements()).isEqualTo(0);
             assertThat(response.getTotalPages()).isEqualTo(0);
         }
-    }
-
-    @Nested
-    @DisplayName("활성 캠페인 조회 테스트")
-    class GetActiveCampaignsByStoreTest {
 
         @Test
-        @DisplayName("매장의 활성 캠페인 목록을 조회한다")
-        void getActiveCampaignsByStore_Success() {
+        @DisplayName("상태로 필터링하여 캠페인 목록을 조회한다")
+        void getCampaignsByStore_WithStatusFilter() {
             // given
+            GetCampaignsByStoreRequest request = GetCampaignsByStoreRequest.builder()
+                .storeId(1L)
+                .status(Campaign.CampaignStatus.ACTIVE)
+                .build();
+            Pageable pageable = PageRequest.of(0, 10);
             List<Campaign> activeCampaigns = Arrays.asList(campaign, activeCampaign);
+            Page<Campaign> campaignPage = new PageImpl<>(activeCampaigns, pageable, activeCampaigns.size());
 
             given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(campaignRepository.findActiveCampaignsByStore(eq(store), any(LocalDateTime.class)))
-                .willReturn(activeCampaigns);
+            given(campaignRepository.findByStoreAndStatusAndIsActiveTrue(store, Campaign.CampaignStatus.ACTIVE, pageable))
+                .willReturn(campaignPage);
 
             // when
-            List<CampaignResponse> responses = campaignQueryService.getActiveCampaignsByStore(1L);
+            PageResponse<CampaignResponse> response = campaignQueryService.getCampaignsByStore(request, pageable);
 
             // then
-            assertThat(responses).hasSize(2);
-            assertThat(responses.get(0).getStatus()).isEqualTo("활성");
-            assertThat(responses.get(1).getStatus()).isEqualTo("활성");
+            assertThat(response.getContent()).hasSize(2);
+            assertThat(response.getTotalElements()).isEqualTo(2);
+            assertThat(response.getContent()).allMatch(c -> c.getStatus().equals("활성"));
 
-            verify(campaignRepository).findActiveCampaignsByStore(eq(store), any(LocalDateTime.class));
-        }
-
-        @Test
-        @DisplayName("활성 캠페인이 없을 때 빈 목록을 반환한다")
-        void getActiveCampaignsByStore_EmptyResult() {
-            // given
-            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(campaignRepository.findActiveCampaignsByStore(eq(store), any(LocalDateTime.class)))
-                .willReturn(List.of());
-
-            // when
-            List<CampaignResponse> responses = campaignQueryService.getActiveCampaignsByStore(1L);
-
-            // then
-            assertThat(responses).isEmpty();
+            verify(campaignRepository).findByStoreAndStatusAndIsActiveTrue(store, Campaign.CampaignStatus.ACTIVE, pageable);
+            verify(campaignRepository, never()).findByStoreAndIsActiveTrue(any(), any());
         }
     }
 
@@ -336,7 +331,6 @@ class CampaignQueryServiceTest {
             assertThat(response.getCampaignId()).isEqualTo(1L);
             assertThat(response.getCampaignName()).isEqualTo("테스트 캠페인");
             assertThat(response.getTotalFeedbackCount()).isEqualTo(75L);
-            assertThat(response.getProgressRate()).isEqualTo(75.0);
             assertThat(response.getAverageSatisfaction()).isEqualTo(4.5);
             assertThat(response.getDailyFeedbacks()).hasSize(5);
 
@@ -367,7 +361,6 @@ class CampaignQueryServiceTest {
 
             // then
             assertThat(response.getTotalFeedbackCount()).isEqualTo(0L);
-            assertThat(response.getProgressRate()).isEqualTo(0.0);
             assertThat(response.getAverageSatisfaction()).isNull();
             assertThat(response.getDailyFeedbacks()).isEmpty();
         }
@@ -386,77 +379,6 @@ class CampaignQueryServiceTest {
 
             // then
             assertThat(response.getDaysRemaining()).isEqualTo(0);
-            assertThat(response.getProgressRate()).isEqualTo(100.0);
-        }
-    }
-
-    @Nested
-    @DisplayName("캠페인 대시보드 조회 테스트")
-    class GetDashboardDataTest {
-
-        @Test
-        @DisplayName("매장의 캠페인 대시보드 데이터를 조회한다")
-        void getDashboardData_Success() {
-            // given
-            List<Campaign> activeCampaigns = Arrays.asList(campaign, activeCampaign);
-
-            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(campaignRepository.findActiveCampaignsByStore(eq(store), any(LocalDateTime.class)))
-                .willReturn(activeCampaigns);
-            given(customerFeedbackRepository.countByFoodItemAndStoreBetweenDates(
-                any(), any(), any(), any()
-            )).willReturn(75L, 40L); // 각 캠페인별 피드백 수
-
-            // when
-            Map<String, Object> dashboard = campaignQueryService.getDashboardData(1L);
-
-            // then
-            assertThat(dashboard).isNotNull();
-            assertThat(dashboard.get("activeCampaignCount")).isEqualTo(2);
-            assertThat(dashboard.get("lastUpdated")).isNotNull();
-
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> campaigns = (List<Map<String, Object>>) dashboard.get("campaigns");
-            assertThat(campaigns).hasSize(2);
-
-            Map<String, Object> firstCampaign = campaigns.get(0);
-            assertThat(firstCampaign.get("campaignId")).isEqualTo(1L);
-            assertThat(firstCampaign.get("campaignName")).isEqualTo("테스트 캠페인");
-            assertThat(firstCampaign.get("foodItemName")).isEqualTo("테스트 음식");
-            assertThat(firstCampaign.get("targetCount")).isEqualTo(100);
-            assertThat(firstCampaign.get("currentCount")).isEqualTo(75L);
-            assertThat(firstCampaign.get("progressRate")).isEqualTo(75.0);
-            assertThat(firstCampaign.get("status")).isEqualTo("활성");
-        }
-
-        @Test
-        @DisplayName("활성 캠페인이 없는 매장의 대시보드를 조회한다")
-        void getDashboardData_NoCampaigns() {
-            // given
-            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(campaignRepository.findActiveCampaignsByStore(eq(store), any(LocalDateTime.class)))
-                .willReturn(List.of());
-
-            // when
-            Map<String, Object> dashboard = campaignQueryService.getDashboardData(1L);
-
-            // then
-            assertThat(dashboard.get("activeCampaignCount")).isEqualTo(0);
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> campaigns = (List<Map<String, Object>>) dashboard.get("campaigns");
-            assertThat(campaigns).isEmpty();
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 매장의 대시보드 조회 시 예외가 발생한다")
-        void getDashboardData_StoreNotFound() {
-            // given
-            given(storeRepository.findById(999L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> campaignQueryService.getDashboardData(999L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOT_FOUND);
         }
     }
 
@@ -479,12 +401,11 @@ class CampaignQueryServiceTest {
             // then
             assertThat(response).isNotNull();
             assertThat(response.getCurrentFeedbackCount()).isEqualTo(75L);
-            assertThat(response.getProgressRate()).isEqualTo(75.0);
             assertThat(response.getTargetFeedbackCount()).isEqualTo(100);
         }
 
         @Test
-        @DisplayName("목표를 초과한 캠페인의 진행률은 100%를 넘지 않는다")
+        @DisplayName("목표를 초과한 캠페인의 피드백 수를 조회한다")
         void getCampaignWithProgress_ExceedTarget() {
             // given
             given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
@@ -497,7 +418,7 @@ class CampaignQueryServiceTest {
 
             // then
             assertThat(response.getCurrentFeedbackCount()).isEqualTo(150L);
-            assertThat(response.getProgressRate()).isEqualTo(100.0); // 100%를 넘지 않음
+            assertThat(response.getTargetFeedbackCount()).isEqualTo(100);
         }
     }
 }


### PR DESCRIPTION
- CampaignQueryService의 getCampaignById에 transactional 추가 (쓰기 작업 허용)
- ErrorMessage 중복 상수 제거 (FOOD_ITEM_NOT_FOUND, UNAUTHORIZED_ACCESS)
- CreateCampaignRequest의 max(10000)을 max(100)으로 통일
- CampaignCommandService에 canManageStore() 권한 체크 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Store campaign list now supports status filtering and pagination via a request body.
  - Campaign responses include campaign duration (targetDays).

- Refactor
  - Replaced start/end date inputs with targetDays for create/update.
  - Streamlined store campaign listing to a single POST endpoint; removed legacy endpoints.
  - Removed progressRate and created/updated timestamps from campaign detail/statistics.

- Security
  - Stricter permission checks for creating, updating, deleting, and changing campaign status.

- Documentation
  - Added optimization and architecture roadmap document.

- Tests
  - Updated tests to reflect request-body listing and targetDays-based flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->