### PR TITLE
refactor: 스웨거 구조 변경 -> 클라이언트가 섹션별로 사장님과 손님의 api를 나눠서 볼 수 있음

### DIFF
--- a/src/main/java/com/example/chalpuplatform/campaign/controller/CampaignController.java
+++ b/src/main/java/com/example/chalpuplatform/campaign/controller/CampaignController.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,6 +33,7 @@ public class CampaignController {
     // Command operations
     @PostMapping
     @Operation(summary = "캠페인 생성", description = "새로운 캠페인을 생성합니다")
+    @PreAuthorize("hasRole('OWNER')")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "캠페인 생성 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
@@ -49,6 +51,7 @@ public class CampaignController {
 
     @PutMapping
     @Operation(summary = "캠페인 수정", description = "기존 캠페인 정보를 수정합니다")
+    @PreAuthorize("hasRole('OWNER')")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "캠페인 수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
@@ -65,6 +68,7 @@ public class CampaignController {
 
     @DeleteMapping
     @Operation(summary = "캠페인 삭제", description = "캠페인을 소프트 삭제합니다")
+    @PreAuthorize("hasRole('OWNER')")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "캠페인 삭제 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "활성 상태 캠페인은 삭제 불가"),
@@ -81,6 +85,7 @@ public class CampaignController {
 
     @PatchMapping("/status")
     @Operation(summary = "캠페인 상태 변경", description = "캠페인의 상태를 변경합니다")
+    @PreAuthorize("hasRole('OWNER')")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "캠페인 상태 변경 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 상태"),
@@ -111,6 +116,7 @@ public class CampaignController {
 
     @PostMapping("/store/list")
     @Operation(summary = "매장별 캠페인 목록 조회", description = "특정 매장의 캠페인 목록을 페이징하여 조회합니다. 상태로 필터링 가능")
+    @PreAuthorize("hasRole('OWNER')")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "캠페인 목록 조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "매장을 찾을 수 없음")

--- a/src/main/java/com/example/chalpuplatform/customerfeedback/controller/CustomerFeedbackController.java
+++ b/src/main/java/com/example/chalpuplatform/customerfeedback/controller/CustomerFeedbackController.java
@@ -108,6 +108,7 @@ public class CustomerFeedbackController {
         summary = "사장님이 매장별 피드백(리뷰) 목록 조회하는 API",
         description = "특정 매장에 대한 모든 고객 피드백을 페이징으로 조회합니다. 매장 사장이 고객 반응을 확인할 때 사용합니다. 기본 20개씩 최신 순으로 정렬됩니다."
     )
+    @PreAuthorize("hasRole('OWNER')")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200",
@@ -137,6 +138,7 @@ public class CustomerFeedbackController {
         summary = "사장님이 음식별 피드백(리뷰) 목록 조회하는 API",
         description = "특정 음식에 대한 모든 고객 피드백을 페이징으로 조회합니다. 매장 사장이 특정 음식에 대한 고객 반응을 확인할 때 사용합니다. 기본 20개씩 최신 순으로 정렬됩니다."
     )
+    @PreAuthorize("hasRole('OWNER')")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200",

--- a/src/main/java/com/example/chalpuplatform/fooditem/controller/FoodItemController.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/controller/FoodItemController.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -38,6 +39,7 @@ public class FoodItemController {
         description = "특정 매장의 음식 목록을 페이지네이션하여 조회합니다.",
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<PageResponse<FoodItemResponse>> getFoodItems(
             @PathVariable @Parameter(description = "매장 ID") Long storeId,
             @PageableDefault(size = 20) Pageable pageable) {
@@ -62,6 +64,7 @@ public class FoodItemController {
         description = "새로운 음식을 생성합니다.",
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<FoodItemResponse> createFoodItem(
             @PathVariable @Parameter(description = "매장 ID") Long storeId,
             @RequestBody FoodItemRequest request,
@@ -76,6 +79,7 @@ public class FoodItemController {
         description = "기존 음식 정보를 수정합니다.",
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<FoodItemResponse> updateFoodItem(
             @PathVariable @Parameter(description = "음식 ID") Long foodId,
             @RequestBody FoodItemRequest request,
@@ -90,6 +94,7 @@ public class FoodItemController {
         description = "음식을 삭제합니다 (소프트 딜리트).",
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<Void> deleteFoodItem(
             @PathVariable @Parameter(description = "음식 ID") Long foodId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -103,6 +108,7 @@ public class FoodItemController {
         description = "메뉴판 이미지를 업로드하여 AI로 메뉴 정보를 추출하고 FoodItem으로 저장합니다.",
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<FoodItemExtractionStartResponse> startMenuExtraction(
             @RequestPart("image") MultipartFile image,
             @RequestParam("storeId") Long storeId,
@@ -122,6 +128,7 @@ public class FoodItemController {
         description = "메뉴 추출 작업의 진행 상태를 조회합니다 (Polling용)",
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<FoodItemExtractionStatusResponse> getExtractionStatus(
             @PathVariable("requestId") String requestId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -137,6 +144,7 @@ public class FoodItemController {
         description = "특정 음식의 대표 사진 URL을 설정합니다.",
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<FoodItemResponse> updateThumbnail(
             @PathVariable("foodId") @Parameter(description = "음식 ID") Long foodId,
             @RequestParam("photoUrl") @Parameter(description = "대표 사진 URL") String photoUrl,

--- a/src/main/java/com/example/chalpuplatform/jar/controller/JARAnalysisController.java
+++ b/src/main/java/com/example/chalpuplatform/jar/controller/JARAnalysisController.java
@@ -6,6 +6,7 @@ import com.example.chalpuplatform.jar.service.JARAnalysisApplicationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -22,6 +23,7 @@ public class JARAnalysisController {
      * 단일 질문 JAR 분석
      */
     @GetMapping("/questions/{questionId}/analysis")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<SingleJARResponse> analyzeQuestion(
             @PathVariable("questionId") Long questionId) {
         log.info("event=jar_analysis_requested, question_id={}", questionId);
@@ -34,6 +36,7 @@ public class JARAnalysisController {
      * 특정 음식 JAR 분석
      */
     @GetMapping("/foods/{foodId}/analysis")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<JARAnalysisResponse> analyzeFoodItem(
             @PathVariable("foodId") Long foodId,
             @RequestParam(value = "startDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,

--- a/src/main/java/com/example/chalpuplatform/oauth/config/OpenApiConfig.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/config/OpenApiConfig.java
@@ -9,9 +9,12 @@ import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.servers.Server;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.client.RestTemplate;
+import java.lang.reflect.Method;
 
 @Configuration
 @OpenAPIDefinition(
@@ -48,11 +51,47 @@ import org.springframework.web.client.RestTemplate;
     in = SecuritySchemeIn.HEADER
 )
 public class OpenApiConfig {
-    
+
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }
 
-    // 필요한 경우 추가 설정을 여기에 구현
+    @Bean
+    public GroupedOpenApi ownerApi() {
+        return GroupedOpenApi.builder()
+            .group("1. 사장님 API")
+            .pathsToMatch("/api/**")
+            .packagesToScan("com.example.chalpuplatform")
+            .addOpenApiMethodFilter(method -> hasRole(method, "OWNER"))
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi customerApi() {
+        return GroupedOpenApi.builder()
+            .group("2. 손님 API")
+            .pathsToMatch("/api/**")
+            .packagesToScan("com.example.chalpuplatform")
+            .addOpenApiMethodFilter(method -> hasRole(method, "CUSTOMER"))
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi commonApi() {
+        return GroupedOpenApi.builder()
+            .group("3. 공통 API")
+            .pathsToMatch("/api/**")
+            .packagesToScan("com.example.chalpuplatform")
+            .addOpenApiMethodFilter(method -> !method.isAnnotationPresent(PreAuthorize.class))
+            .build();
+    }
+
+    private boolean hasRole(Method method, String role) {
+        if (method.isAnnotationPresent(PreAuthorize.class)) {
+            PreAuthorize preAuthorize = method.getAnnotation(PreAuthorize.class);
+            return preAuthorize.value().contains(role);
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/example/chalpuplatform/reward/controller/RewardController.java
+++ b/src/main/java/com/example/chalpuplatform/reward/controller/RewardController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,6 +46,7 @@ public class RewardController {
             )
         )
     })
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<List<RewardResponse>>> getAllRewards() {
         List<RewardResponse> responses = rewardService.getAvailableRewards();
         return ResponseEntity.ok(ApiResponse.success(responses));
@@ -68,6 +70,7 @@ public class RewardController {
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다")
     })
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<List<RewardResponse>>> getMyAvailableRewards(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
         
@@ -96,6 +99,7 @@ public class RewardController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리워드를 찾을 수 없습니다")
     })
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<RewardRedemptionResponse>> redeemReward(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -133,6 +137,7 @@ public class RewardController {
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다")
     })
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<List<RewardRedemptionResponse>>> getMyRedemptions(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
         
@@ -158,6 +163,7 @@ public class RewardController {
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다")
     })
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<List<RewardRedemptionResponse>>> getMyActiveRedemptions(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
         
@@ -184,6 +190,7 @@ public class RewardController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (이미 사용된 리워드, 만료된 리워드 등)"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리워드 교환 내역을 찾을 수 없습니다")
     })
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<Void>> markRedemptionAsUsed(
             @Parameter(description = "교환 ID", example = "1")
             @PathVariable("redemptionId") Long redemptionId) {
@@ -211,6 +218,7 @@ public class RewardController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (사용되지 않은 리워드, 만료된 리워드 등)"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리워드 교환 내역을 찾을 수 없습니다")
     })
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<Void>> cancelRedemption(
             @Parameter(description = "교환 ID", example = "1")
             @PathVariable("redemptionId") Long redemptionId) {
@@ -237,6 +245,7 @@ public class RewardController {
         ),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다")
     })
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<Boolean>> checkMyRewardEligibility(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
         

--- a/src/main/java/com/example/chalpuplatform/store/controller/StoreController.java
+++ b/src/main/java/com/example/chalpuplatform/store/controller/StoreController.java
@@ -117,6 +117,7 @@ public class StoreController {
 
     @DeleteMapping("/{storeId}")
     @Operation(summary = "매장 삭제", description = "매장을 삭제합니다. 소유자만 삭제할 수 있습니다.")
+    @PreAuthorize("hasRole('OWNER')")
     public ResponseEntity<ApiResponse<Void>> deleteStore(
             @PathVariable Long storeId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -132,6 +133,7 @@ public class StoreController {
 
     @GetMapping("/{storeId}/members")
     @Operation(summary = "매장 멤버 목록 조회", description = "매장에 속한 멤버 목록을 조회합니다.")
+    @PreAuthorize("hasRole('OWNER')")
     public ResponseEntity<ApiResponse<List<MemberResponse>>> getStoreMembers(
             @PathVariable Long storeId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -142,6 +144,7 @@ public class StoreController {
 
     @PostMapping("/{storeId}/members")
     @Operation(summary = "매장 멤버 초대", description = "매장에 새로운 멤버를 초대합니다.")
+    @PreAuthorize("hasRole('OWNER')")
     public ResponseEntity<ApiResponse<MemberResponse>> inviteMember(
             @PathVariable Long storeId,
             @RequestBody MemberInviteRequest memberRequest,

--- a/src/main/java/com/example/chalpuplatform/user/controller/UserController.java
+++ b/src/main/java/com/example/chalpuplatform/user/controller/UserController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -63,6 +64,7 @@ public class UserController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @GetMapping("/profile/taste")
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<CustomerTasteDto>> getCustomerTaste(
             @AuthenticationPrincipal UserDetailsImpl currentUser) {
         
@@ -80,6 +82,7 @@ public class UserController {
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @PutMapping("/profile/taste")
+    @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<ApiResponse<CustomerTasteDto>> updateCustomerTaste(
             @AuthenticationPrincipal UserDetailsImpl currentUser,
             @RequestBody CustomerTasteDto customerTasteDto) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced role-based access across the app. Owner-only: campaigns, food items, JAR analysis, and selected store management actions. Customer-only: rewards and taste profile endpoints.
- Documentation
  - API docs now grouped by role (Owner, Customer, Common) for clearer navigation and discoverability.
- Chores
  - Standardized access rules on multiple endpoints to ensure consistent role enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->