### PR TITLE
feat: AuthProvider enum에 GOOGLE을 추가했습니다

### DIFF
--- a/src/main/java/com/example/chalpuplatform/oauth/model/AuthProvider.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/model/AuthProvider.java
@@ -4,7 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "인증 제공자 유형")
 public enum AuthProvider {
-    @Schema(description = "Kakao 로그인") KAKAO;
+    @Schema(description = "Kakao 로그인") KAKAO,
+    @Schema(description = "Google 로그인") GOOGLE;
     /**
      * 문자열로부터 AuthProvider를 반환합니다.
      * @param value 인증 제공자 문자열 (대소문자 무관)

--- a/src/main/java/com/example/chalpuplatform/oauth/provider/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/provider/OAuth2UserInfoFactory.java
@@ -12,6 +12,8 @@ public class OAuth2UserInfoFactory {
         switch (authProvider) {
             case KAKAO:
                 return new KakaoOAuth2UserInfo(attributes);
+            case GOOGLE:
+                return new GoogleOAuth2UserInfo(attributes);
             default:
                 throw new OAuthException(ErrorMessage.OAUTH_PROVIDER_NOT_SUPPORTED);
         }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,7 +35,7 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ${kakao-client-id} # 웹용 클라이언트 ID
+            client-id: ${kakao-client-id}
             client-secret: ${kakao-client-secret}
             redirect-uri: "https://platform.chalpu.com/api/login/oauth2/code/kakao"
             authorization-grant-type: authorization_code
@@ -43,12 +43,25 @@ spring:
             scope:
               - profile_nickname
               - account_email
+          google:
+            client-id: ${google-client-id}
+            client-secret: ${google-client-secret}
+            redirect-uri: "https://platform.chalpu.com/api/login/oauth2/code/google"
+            authorization-grant-type: authorization_code
+            scope:
+              - profile
+              - email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
 
 jwt:
   secret: ${jwt-secret}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -46,7 +46,13 @@ spring:
               - name
               - email
           google:
-            client-id: ${GOOGLE_CLIENT_IDS}
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "https://prod.chalpu.com/api/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope:
+              - profile
+              - email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
@@ -58,6 +64,11 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
   application:
     name: chalpu
 

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -48,6 +48,8 @@ module "parameter_store" {
   aws_secret_key             = var.aws_secret_key
   kakao_client_id           = var.kakao_client_id
   kakao_client_secret       = var.kakao_client_secret
+  google_client_id          = var.google_client_id
+  google_client_secret      = var.google_client_secret
   oauth2_redirect_success_path = var.oauth2_redirect_success_path
   oauth2_redirect_failure_path = var.oauth2_redirect_failure_path
   oauth2_owner_domain       = var.oauth2_owner_domain

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -109,6 +109,17 @@ variable "kakao_client_secret" {
   sensitive   = true
 }
 
+variable "google_client_id" {
+  description = "Google OAuth client ID"
+  type        = string
+}
+
+variable "google_client_secret" {
+  description = "Google OAuth client secret"
+  type        = string
+  sensitive   = true
+}
+
 variable "oauth2_redirect_success_path" {
   description = "OAuth2 redirect success path"
   type        = string

--- a/terraform/modules/secret/parameter-store/main.tf
+++ b/terraform/modules/secret/parameter-store/main.tf
@@ -122,6 +122,31 @@ resource "aws_ssm_parameter" "kakao_client_secret" {
   }
 }
 
+# OAuth Google Configuration
+resource "aws_ssm_parameter" "google_client_id" {
+  name        = "/chalpu-platform/${var.environment}/google-client-id"
+  description = "Google OAuth client ID"
+  type        = "String"
+  value       = var.google_client_id
+
+  tags = {
+    Name        = "chalpu-${var.environment}-google-client-id"
+    Environment = var.environment
+  }
+}
+
+resource "aws_ssm_parameter" "google_client_secret" {
+  name        = "/chalpu-platform/${var.environment}/google-client-secret"
+  description = "Google OAuth client secret"
+  type        = "SecureString"
+  value       = var.google_client_secret
+
+  tags = {
+    Name        = "chalpu-${var.environment}-google-client-secret"
+    Environment = var.environment
+  }
+}
+
 # OAuth2 Redirect Configuration
 resource "aws_ssm_parameter" "oauth2_redirect_success_path" {
   name        = "/chalpu-platform/${var.environment}/oauth2-redirect-success-path"

--- a/terraform/modules/secret/parameter-store/variables.tf
+++ b/terraform/modules/secret/parameter-store/variables.tf
@@ -61,6 +61,17 @@ variable "kakao_client_secret" {
   sensitive   = true
 }
 
+variable "google_client_id" {
+  description = "Google OAuth client ID"
+  type        = string
+}
+
+variable "google_client_secret" {
+  description = "Google OAuth client secret"
+  type        = string
+  sensitive   = true
+}
+
 variable "oauth2_redirect_success_path" {
   description = "OAuth2 redirect success path"
   type        = string


### PR DESCRIPTION
  ### 변경 내용
  - 구글 OAuth 2.0 로그인 기능을 추가했습니다
  - AuthProvider enum에 GOOGLE 추가
  - OAuth2UserInfoFactory에 구글 사용자 정보 파싱 로직 추가
  - application-dev.yml, application-prod.yml에 구글 OAuth 클라이언트 설정 추가
  - Terraform 인프라 코드에 구글 OAuth 설정을 AWS Parameter Store에 저장하는 리소스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google as a sign-in option, expanding OAuth login choices.

* **Chores**
  * Updated application configuration for Google OAuth across development and production environments.
  * Provisioned secure storage for Google OAuth credentials in infrastructure parameter store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->