### PR TITLE
feat: 매장별 음식 모두 조회 추가

### DIFF
--- a/src/main/java/com/example/chalpuplatform/fooditem/controller/FoodItemController.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/controller/FoodItemController.java
@@ -36,10 +36,8 @@ public class FoodItemController {
     @GetMapping("/store/{storeId}")
     @Operation(
         summary = "매장별 음식 목록 조회",
-        description = "특정 매장의 음식 목록을 페이지네이션하여 조회합니다.",
-        security = { @SecurityRequirement(name = "bearerAuth") }
+        description = "특정 매장의 음식 목록을 페이지네이션하여 조회합니다."
     )
-    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<PageResponse<FoodItemResponse>> getFoodItems(
             @PathVariable @Parameter(description = "매장 ID") Long storeId,
             @PageableDefault(size = 20) Pageable pageable) {

--- a/src/main/java/com/example/chalpuplatform/fooditem/service/FoodItemService.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/service/FoodItemService.java
@@ -183,4 +183,8 @@ public class FoodItemService {
             throw new FoodException(ErrorMessage.STORE_ACCESS_DENIED);
         }
     }
-} 
+
+    public PageResponse<FoodItemResponse> getAllFoodItems() {
+        return null;
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/store/controller/StoreController.java
+++ b/src/main/java/com/example/chalpuplatform/store/controller/StoreController.java
@@ -153,4 +153,13 @@ public class StoreController {
         MemberResponse member = userStoreRoleService.inviteMember(storeId, memberRequest, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.success(member));
     }
+
+    @GetMapping("/all")
+    @Operation(summary = "전체 매장 매장 목록 조회", description = "전체 매장 목록을 페이지네이션으로 조회합니다.")
+    public ResponseEntity<ApiResponse<PageResponse<StoreResponse>>> getAllStores(
+            @Parameter(description = "페이지네이션 정보")
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        PageResponse<StoreResponse> stores = storeService.getAllStores(pageable);
+        return ResponseEntity.ok(ApiResponse.success(stores));
+    }
 } 

--- a/src/main/java/com/example/chalpuplatform/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/chalpuplatform/store/repository/StoreRepository.java
@@ -1,6 +1,8 @@
 package com.example.chalpuplatform.store.repository;
 
 import com.example.chalpuplatform.store.domain.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +15,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByIdAndIsActiveTrue(Long id);
     
     List<Store> findByIsActiveTrue();
+
+    Page<Store> findByIsActiveTrue(Pageable pageable);
 } 

--- a/src/main/java/com/example/chalpuplatform/store/service/StoreService.java
+++ b/src/main/java/com/example/chalpuplatform/store/service/StoreService.java
@@ -2,6 +2,7 @@ package com.example.chalpuplatform.store.service;
 
 import com.example.chalpuplatform.common.exception.ErrorMessage;
 import com.example.chalpuplatform.common.exception.StoreException;
+import com.example.chalpuplatform.common.response.PageResponse;
 import com.example.chalpuplatform.fooditem.domain.FoodItem;
 import com.example.chalpuplatform.photo.repository.PhotoRepository;
 import com.example.chalpuplatform.store.domain.Store;
@@ -12,6 +13,7 @@ import com.example.chalpuplatform.store.repository.StoreRepository;
 import com.example.chalpuplatform.store.repository.UserStoreRoleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -100,4 +102,10 @@ public class StoreService {
             throw new StoreException(ErrorMessage.STORE_DELETE_FAILED);
         }
     }
-} 
+
+    public PageResponse<StoreResponse> getAllStores(Pageable pageable) {
+        return PageResponse.from(
+                storeRepository.findByIsActiveTrue(pageable).map(StoreResponse::from)
+        );
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a paginated “All Stores” endpoint to browse active stores, with sensible defaults (page size 10, newest first) and support for standard pagination controls.
  * Made store food items publicly viewable: you can now access a store’s menu without signing in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->