### PR TITLE
refactor: profile 설정 to local

### DIFF
--- a/src/main/java/com/example/chalpuplatform/test/TestTokenController.java
+++ b/src/main/java/com/example/chalpuplatform/test/TestTokenController.java
@@ -31,7 +31,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/test")
 @RequiredArgsConstructor
-@Profile({"!dev & !prod"}) // dev, prod 환경에서는 이 컨트롤러가 활성화되지 않음
+@Profile({"local"}) // dev, prod 환경에서는 이 컨트롤러가 활성화되지 않음
 @Tag(name = "Test", description = "테스트 API")
 public class TestTokenController {
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Restricted the test token endpoint to local environments only. It is no longer accessible in dev, staging, or production.
  - No changes to other endpoints or features.

- Documentation
  - Clarified environment availability for the test token endpoint in internal notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->