### PR TITLE
feat: Store와 FoodItem 엔티티에 카운트 캐시 필드를 추가했습니다

### DIFF
--- a/src/main/java/com/example/chalpuplatform/customerfeedback/service/CustomerFeedbackService.java
+++ b/src/main/java/com/example/chalpuplatform/customerfeedback/service/CustomerFeedbackService.java
@@ -123,6 +123,12 @@ public class CustomerFeedbackService {
 
         CustomerFeedback savedFeedback = feedbackRepository.save(feedback);
 
+        // Store와 FoodItem의 피드백 카운트 원자적 증가
+        storeRepository.incrementFeedbackCount(store.getId());
+        foodItemRepository.incrementFeedbackCount(foodItem.getId());
+        log.info("피드백 카운트 증가: storeId={}, foodItemId={}, feedbackId={}",
+                store.getId(), foodItem.getId(), savedFeedback.getId());
+
         // 캠페인 연결 시 카운트 원자적 증가
         if (campaign != null) {
             campaignRepository.incrementFeedbackCount(campaign.getId());

--- a/src/main/java/com/example/chalpuplatform/fooditem/domain/FoodItem.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/domain/FoodItem.java
@@ -44,6 +44,10 @@ public class FoodItem extends BaseTimeEntity {
     @Builder.Default
     private Boolean isActive = true;
 
+    @Builder.Default
+    @Column(name = "feedback_count", nullable = false)
+    private Long feedbackCount = 0L;
+
     // 정적 팩토리 메서드
     public static FoodItem createFoodItem(Store store, FoodItemRequest request) {
         return FoodItem.builder()

--- a/src/main/java/com/example/chalpuplatform/fooditem/dto/FoodItemResponse.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/dto/FoodItemResponse.java
@@ -43,9 +43,12 @@ public class FoodItemResponse {
 
     @Schema(description = "생성 시간", example = "2024-01-15T09:30:00")
     private LocalDateTime createdAt;
-    
+
     @Schema(description = "수정 시간", example = "2024-01-15T10:30:00")
     private LocalDateTime updatedAt;
+
+    @Schema(description = "피드백 개수", example = "23")
+    private Long feedbackCount;
     
     public static FoodItemResponse from(FoodItem foodItem) {
         return FoodItemResponse.builder()
@@ -59,6 +62,7 @@ public class FoodItemResponse {
                 .isActive(foodItem.getIsActive())
                 .createdAt(foodItem.getCreatedAt())
                 .updatedAt(foodItem.getUpdatedAt())
+                .feedbackCount(foodItem.getFeedbackCount())
                 .build();
     }
 } 

--- a/src/main/java/com/example/chalpuplatform/fooditem/repository/FoodItemRepository.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/repository/FoodItemRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -30,4 +31,12 @@ public interface FoodItemRepository extends JpaRepository<FoodItem, Long> {
     // 메뉴 추출을 위한 중복 체크용 메서드
     @Query("SELECT fi FROM FoodItem fi WHERE fi.store.id = :storeId AND fi.foodName = :foodName AND fi.isActive = true")
     Optional<FoodItem> findByStoreIdAndFoodName(@Param("storeId") Long storeId, @Param("foodName") String foodName);
+
+    @Modifying
+    @Query("UPDATE FoodItem f SET f.feedbackCount = f.feedbackCount + 1 WHERE f.id = :foodItemId")
+    void incrementFeedbackCount(@Param("foodItemId") Long foodItemId);
+
+    @Modifying
+    @Query("UPDATE FoodItem f SET f.feedbackCount = f.feedbackCount - 1 WHERE f.id = :foodItemId AND f.feedbackCount > 0")
+    void decrementFeedbackCount(@Param("foodItemId") Long foodItemId);
 } 

--- a/src/main/java/com/example/chalpuplatform/fooditem/service/FoodItemService.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/service/FoodItemService.java
@@ -70,6 +70,9 @@ public class FoodItemService {
         FoodItem foodItem = FoodItem.createFoodItem(store, foodItemRequest);
         FoodItem savedFoodItem = foodItemRepository.save(foodItem);
 
+        // Store의 메뉴 카운트 원자적 증가
+        storeRepository.incrementMenuCount(storeId);
+
         log.info("event=food_item_created, food_item_id={}, store_id={}, user_id={}",
                 savedFoodItem.getId(), storeId, userId);
 
@@ -116,12 +119,15 @@ public class FoodItemService {
         // 1. 연관된 Photo들 소프트 딜리트
         photoRepository.softDeleteByFoodItemId(foodItemId);
 
-        // 3. FoodItem 자체 소프트 딜리트
+        // 2. FoodItem 자체 소프트 딜리트
         FoodItem foodItem = foodItemRepository.findByIdAndIsActiveTrueWithoutJoin(foodItemId)
                 .orElseThrow(() -> new FoodException(ErrorMessage.FOOD_NOT_FOUND));
         foodItem.softDelete();
 
         foodItemRepository.save(foodItem);
+
+        // 3. Store의 메뉴 카운트 원자적 감소
+        storeRepository.decrementMenuCount(storeId);
 
         log.info("event=food_item_deleted, food_item_id={}, store_id={}", foodItemId, storeId);
     }

--- a/src/main/java/com/example/chalpuplatform/store/controller/StoreController.java
+++ b/src/main/java/com/example/chalpuplatform/store/controller/StoreController.java
@@ -155,4 +155,16 @@ public class StoreController {
         PageResponse<StoreResponse> stores = storeService.getAllStores(pageable);
         return ResponseEntity.ok(ApiResponse.success(stores));
     }
+
+    @PutMapping("/{storeId}/thumbnail")
+    @Operation(summary = "매장 대표 사진 설정", description = "매장의 대표 사진 URL을 설정합니다.")
+    @PreAuthorize("hasRole('OWNER')")
+    public ResponseEntity<ApiResponse<StoreResponse>> updateStoreThumbnail(
+            @PathVariable("storeId") @Parameter(description = "매장 ID") Long storeId,
+            @RequestParam("photoUrl") @Parameter(description = "대표 사진 URL") String photoUrl,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        StoreResponse response = storeService.updateStoreThumbnail(storeId, photoUrl, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 } 

--- a/src/main/java/com/example/chalpuplatform/store/domain/Store.java
+++ b/src/main/java/com/example/chalpuplatform/store/domain/Store.java
@@ -37,6 +37,17 @@ public class Store extends BaseTimeEntity {
     @Schema(description = "가게 설명",nullable = true)
     private String description;
 
+    @Builder.Default
+    @Column(name = "feedback_count", nullable = false)
+    private Long feedbackCount = 0L;
+
+    @Builder.Default
+    @Column(name = "menu_count", nullable = false)
+    private Long menuCount = 0L;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
     @Embedded
     private DeliveryPlatformLinks deliveryPlatformLinks;
     
@@ -74,5 +85,9 @@ public class Store extends BaseTimeEntity {
 
     public void softDelete() {
         this.isActive = false;
+    }
+
+    public void setThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
     }
 } 

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreResponse.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreResponse.java
@@ -36,6 +36,15 @@ public class StoreResponse {
 
     @Schema(description = "가게 설명", example = "저희 가게는 신선한 재료로 음식을 만듭니다.")
     private String description;
+
+    @Schema(description = "피드백 개수", example = "42")
+    private Long feedbackCount;
+
+    @Schema(description = "메뉴 개수", example = "15")
+    private Long menuCount;
+
+    @Schema(description = "썸네일 URL", example = "https://chalpu.s3.ap-northeast-2.amazonaws.com/stores/1/thumbnail.jpg")
+    private String thumbnailUrl;
     
 
     public static StoreResponse from(Store store) {
@@ -44,6 +53,9 @@ public class StoreResponse {
                 .storeName(store.getStoreName())
                 .address(store.getAddress())
                 .description(store.getDescription())
+                .feedbackCount(store.getFeedbackCount())
+                .menuCount(store.getMenuCount())
+                .thumbnailUrl(store.getThumbnailUrl())
                 .baeminLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getBaeminLink() != null
                         ? store.getDeliveryPlatformLinks().getBaeminLink() : "")
                 .yogiyoLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getYogiyoLink() != null

--- a/src/main/java/com/example/chalpuplatform/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/chalpuplatform/store/repository/StoreRepository.java
@@ -4,6 +4,9 @@ import com.example.chalpuplatform.store.domain.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,8 +16,24 @@ import java.util.Optional;
 public interface StoreRepository extends JpaRepository<Store, Long> {
     
     Optional<Store> findByIdAndIsActiveTrue(Long id);
-    
+
     List<Store> findByIsActiveTrue();
 
     Page<Store> findByIsActiveTrue(Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Store s SET s.feedbackCount = s.feedbackCount + 1 WHERE s.id = :storeId")
+    void incrementFeedbackCount(@Param("storeId") Long storeId);
+
+    @Modifying
+    @Query("UPDATE Store s SET s.feedbackCount = s.feedbackCount - 1 WHERE s.id = :storeId AND s.feedbackCount > 0")
+    void decrementFeedbackCount(@Param("storeId") Long storeId);
+
+    @Modifying
+    @Query("UPDATE Store s SET s.menuCount = s.menuCount + 1 WHERE s.id = :storeId")
+    void incrementMenuCount(@Param("storeId") Long storeId);
+
+    @Modifying
+    @Query("UPDATE Store s SET s.menuCount = s.menuCount - 1 WHERE s.id = :storeId AND s.menuCount > 0")
+    void decrementMenuCount(@Param("storeId") Long storeId);
 } 

--- a/src/main/java/com/example/chalpuplatform/store/service/StoreService.java
+++ b/src/main/java/com/example/chalpuplatform/store/service/StoreService.java
@@ -108,4 +108,21 @@ public class StoreService {
                 storeRepository.findByIsActiveTrue(pageable).map(StoreResponse::from)
         );
     }
+
+    public StoreResponse updateStoreThumbnail(Long storeId, String photoUrl, Long userId) {
+        try {
+            Store store = storeRepository.findByIdAndIsActiveTrue(storeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+
+            store.setThumbnailUrl(photoUrl);
+            Store savedStore = storeRepository.save(store);
+
+            log.info("매장 대표 사진 설정: storeId={}, photoUrl={}, userId={}", storeId, photoUrl, userId);
+            return StoreResponse.from(savedStore);
+        } catch (Exception e) {
+            log.error("event=store_thumbnail_update_failed, store_id={}, error_message={}",
+                    storeId, e.getMessage(), e);
+            throw new StoreException(ErrorMessage.STORE_UPDATE_FAILED);
+        }
+    }
 }


### PR DESCRIPTION
  ### 변경 내용
  - Store 엔티티에 feedbackCount, menuCount, thumbnailUrl 필드를 추가했습니다
  - FoodItem 엔티티에 feedbackCount 필드를 추가했습니다
  - StoreRepository와 FoodItemRepository에 원자적 카운트 증감 메서드를 추가했습니다
  - StoreResponse와 FoodItemResponse DTO에 카운트 필드를 추가했습니다
  - CustomerFeedbackService에 피드백 생성 시 Store, FoodItem 카운트 자동 증가 로직을 추가했습니다
  - FoodItemService에 메뉴 생성/삭제 시 Store 메뉴 카운트 자동 증감 로직을 추가했습니다
  - PUT /api/stores/{storeId}/thumbnail 엔드포인트를 추가했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Store details now include feedback count, menu count, and thumbnail URL.
  - Food item details now display feedback count.
  - New endpoint to update a store’s thumbnail (owner-only), returning the updated store info.
- Improvements
  - Feedback counts automatically update when new feedback is created.
  - Store menu counts automatically update when menu items are created or deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->