### PR TITLE
refactor: 링크 컬럼 타입을 TEXT에서 VARCHAR(255)로 변경했습니다

### DIFF
--- a/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
@@ -64,7 +64,8 @@ public enum ErrorMessage {
     STORE_MEMBER_ALREADY_EXISTS(BAD_REQUEST, "이미 매장 구성원으로 등록되어 있습니다."),
     STORE_OWNER_CANNOT_LEAVE(FORBIDDEN, "소유자는 탈퇴할 수 없습니다. 매장을 다른 사람에게 양도하거나 삭제해야 합니다."),
     STORE_NAME_ALREADY_EXISTS(BAD_REQUEST, "이미 존재하는 매장 이름입니다."),
-    
+    SITE_LINK_ALREADY_EXISTS(BAD_REQUEST, "이미 사용 중인 사이트 링크입니다."),
+
     // 메뉴 관련 에러
     MENU_NOT_FOUND(NOT_FOUND, "메뉴를 찾을 수 없습니다."),
     MENU_ACCESS_DENIED(FORBIDDEN, "메뉴 접근 권한이 없습니다."),

--- a/src/main/java/com/example/chalpuplatform/store/controller/StorePublicController.java
+++ b/src/main/java/com/example/chalpuplatform/store/controller/StorePublicController.java
@@ -24,15 +24,15 @@ public class StorePublicController {
 
     private final StoreRepository storeRepository;
 
-    @GetMapping("/{storeName}")
+    @GetMapping("/{siteLink}")
     @Operation(
-            summary = "매장명으로 매장 조회",
-            description = "매장명으로 매장 ID를 조회합니다. 인증이 필요없는 공개 API입니다."
+            summary = "사이트 링크로 매장 조회",
+            description = "사이트 링크로 매장 ID를 조회합니다. 인증이 필요없는 공개 API입니다."
     )
-    public ResponseEntity<ApiResponse<StoreIdResponse>> getStoreByName(
-            @PathVariable("storeName") @Parameter(description = "매장명") String storeName) {
+    public ResponseEntity<ApiResponse<StoreIdResponse>> getStoreBySiteLink(
+            @PathVariable("siteLink") @Parameter(description = "사이트 링크") String siteLink) {
 
-        Store store = storeRepository.findByStoreName(storeName)
+        Store store = storeRepository.findBySiteLink(siteLink)
                 .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
 
         return ResponseEntity.ok(ApiResponse.success(StoreIdResponse.from(store)));

--- a/src/main/java/com/example/chalpuplatform/store/domain/DeliveryPlatformLinks.java
+++ b/src/main/java/com/example/chalpuplatform/store/domain/DeliveryPlatformLinks.java
@@ -11,13 +11,28 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class DeliveryPlatformLinks {
-    
-    @Column(name = "baemin_link", columnDefinition = "TEXT", nullable = true)
+
+    @Column(name = "baemin_link", length = 255, nullable = true)
     private String baeminLink;
-    
-    @Column(name = "yogiyo_link", columnDefinition = "TEXT", nullable = true)
+
+    @Column(name = "yogiyo_link", length = 255, nullable = true)
     private String yogiyoLink;
-    
-    @Column(name = "coupangeats_link", columnDefinition = "TEXT", nullable = true)
+
+    @Column(name = "coupangeats_link", length = 255, nullable = true)
     private String coupangeatsLink;
+
+    @Column(name = "naver_map_link", length = 255, nullable = true)
+    private String naverLink;
+
+    @Column(name = "kakao_map_link", length = 255, nullable = true)
+    private String kakaoLink;
+
+    @Column(name = "instagram_link", length = 255, nullable = true)
+    private String instagramLink;
+
+    @Column(name = "kakao_talk_link", length = 255, nullable = true)
+    private String kakaoTalkLink;
+
+    @Column(name = "site_link", length = 255, nullable = true)
+    private String siteLink;
 }

--- a/src/main/java/com/example/chalpuplatform/store/domain/Store.java
+++ b/src/main/java/com/example/chalpuplatform/store/domain/Store.java
@@ -24,7 +24,7 @@ public class Store extends BaseTimeEntity {
     @Column(name = "store_id")
     private Long id;
 
-    @Column(length = 100, nullable = false, unique = true)
+    @Column(length = 100, nullable = false)
     private String storeName;
 
     @Column(name = "address")
@@ -42,7 +42,7 @@ public class Store extends BaseTimeEntity {
     private Long feedbackCount = 0L;
 
     @Builder.Default
-    @Column(name = "menu_count", nullable = false)
+@Column(name = "menu_count", nullable = false)
     private Long menuCount = 0L;
 
     @Column(name = "thumbnail_url")
@@ -66,6 +66,11 @@ public class Store extends BaseTimeEntity {
                         .baeminLink(storeRequest.getBaeminLink())
                         .yogiyoLink(storeRequest.getYogiyoLink())
                         .coupangeatsLink(storeRequest.getCoupangeatsLink())
+                        .naverLink(storeRequest.getNaverLink())
+                        .kakaoLink(storeRequest.getKakaoLink())
+                        .instagramLink(storeRequest.getInstagramLink())
+                        .kakaoTalkLink(storeRequest.getKakaoTalkLink())
+                        .siteLink(storeRequest.getSiteLink())
                         .build())
                 .build();
     }
@@ -81,6 +86,11 @@ public class Store extends BaseTimeEntity {
         this.deliveryPlatformLinks.setBaeminLink(storeRequest.getBaeminLink());
         this.deliveryPlatformLinks.setYogiyoLink(storeRequest.getYogiyoLink());
         this.deliveryPlatformLinks.setCoupangeatsLink(storeRequest.getCoupangeatsLink());
+        this.deliveryPlatformLinks.setNaverLink(storeRequest.getNaverLink());
+        this.deliveryPlatformLinks.setKakaoLink(storeRequest.getKakaoLink());
+        this.deliveryPlatformLinks.setInstagramLink(storeRequest.getInstagramLink());
+        this.deliveryPlatformLinks.setKakaoTalkLink(storeRequest.getKakaoTalkLink());
+        this.deliveryPlatformLinks.setSiteLink(storeRequest.getSiteLink());
     }
 
     public void softDelete() {

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreRequest.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreRequest.java
@@ -28,6 +28,21 @@ public class StoreRequest {
     @Schema(description = "쿠팡이츠 링크", example = "https://coupangeats.com/store/12345")
     private String coupangeatsLink;
 
+    @Schema(description = "네이버 지도 링크", example = "https://map.naver.com/v5/entry/place/12345")
+    private String naverLink;
+
+    @Schema(description = "카카오맵 링크", example = "https://place.map.kakao.com/12345")
+    private String kakaoLink;
+
+    @Schema(description = "인스타그램 링크", example = "https://instagram.com/store_account")
+    private String instagramLink;
+
+    @Schema(description = "카카오톡 채널 링크", example = "https://pf.kakao.com/_store")
+    private String kakaoTalkLink;
+
+    @Schema(description = "사이트 링크 (URL 경로용)", example = "우리집냉면")
+    private String siteLink;
+
     @Schema(description = "가게 설명", example = "저희 가게는 신선한 재료로 음식을 만듭니다.")
     private String description;
 } 

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreResponse.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreResponse.java
@@ -34,6 +34,21 @@ public class StoreResponse {
     @Schema(description = "쿠팡이츠 링크", example = "https://www.coupang.com/restaurant/12345")
     private String coupangEatsLink;
 
+    @Schema(description = "네이버 지도 링크", example = "https://map.naver.com/v5/entry/place/12345")
+    private String naverLink;
+
+    @Schema(description = "카카오맵 링크", example = "https://place.map.kakao.com/12345")
+    private String kakaoLink;
+
+    @Schema(description = "인스타그램 링크", example = "https://instagram.com/store_account")
+    private String instagramLink;
+
+    @Schema(description = "카카오톡 채널 링크", example = "https://pf.kakao.com/_store")
+    private String kakaoTalkLink;
+
+    @Schema(description = "사이트 링크 (URL 경로용)", example = "우리집냉면")
+    private String siteLink;
+
     @Schema(description = "가게 설명", example = "저희 가게는 신선한 재료로 음식을 만듭니다.")
     private String description;
 
@@ -62,6 +77,16 @@ public class StoreResponse {
                         ? store.getDeliveryPlatformLinks().getYogiyoLink() : "")
                 .coupangEatsLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getCoupangeatsLink() != null
                         ? store.getDeliveryPlatformLinks().getCoupangeatsLink() : "")
+                .naverLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getNaverLink() != null
+                        ? store.getDeliveryPlatformLinks().getNaverLink() : "")
+                .kakaoLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getKakaoLink() != null
+                        ? store.getDeliveryPlatformLinks().getKakaoLink() : "")
+                .instagramLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getInstagramLink() != null
+                        ? store.getDeliveryPlatformLinks().getInstagramLink() : "")
+                .kakaoTalkLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getKakaoTalkLink() != null
+                        ? store.getDeliveryPlatformLinks().getKakaoTalkLink() : "")
+                .siteLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getSiteLink() != null
+                        ? store.getDeliveryPlatformLinks().getSiteLink() : "")
                 .build();
     }
 } 

--- a/src/main/java/com/example/chalpuplatform/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/chalpuplatform/store/repository/StoreRepository.java
@@ -38,4 +38,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     void decrementMenuCount(@Param("storeId") Long storeId);
 
     Optional<Store> findByStoreName(String storeName);
+
+    @Query("SELECT s FROM Store s WHERE s.deliveryPlatformLinks.siteLink = :siteLink")
+    Optional<Store> findBySiteLink(@Param("siteLink") String siteLink);
 } 

--- a/src/main/java/com/example/chalpuplatform/store/service/StoreService.java
+++ b/src/main/java/com/example/chalpuplatform/store/service/StoreService.java
@@ -44,19 +44,23 @@ public class StoreService {
 
     public StoreResponse createStore(StoreRequest storeRequest) {
         try {
-            Optional<Store> storeName = storeRepository.findByStoreName(storeRequest.getStoreName());
-            if (storeName.isPresent()) {
-                throw new StoreException(ErrorMessage.STORE_NAME_ALREADY_EXISTS);
+            if (storeRequest.getSiteLink() != null && !storeRequest.getSiteLink().isEmpty()) {
+                Optional<Store> existingSiteLink = storeRepository.findBySiteLink(storeRequest.getSiteLink());
+                if (existingSiteLink.isPresent()) {
+                    throw new StoreException(ErrorMessage.SITE_LINK_ALREADY_EXISTS);
+                }
             }
 
             Store store = Store.createStore(storeRequest);
             Store savedStore = storeRepository.save(store);
             log.info("event=store_created, store_id={}", savedStore.getId());
             return StoreResponse.from(savedStore);
+        } catch (StoreException e) {
+            throw e;
         } catch (Exception e) {
             log.error("event=store_creation_failed, store_name={}, error_message={}",
                     storeRequest.getStoreName(), e.getMessage(), e);
-            throw e;
+            throw new StoreException(ErrorMessage.STORE_CREATE_FAILED);
         }
     }
 

--- a/src/main/resources/db/migration/V10__add_site_link_unique_constraint.sql
+++ b/src/main/resources/db/migration/V10__add_site_link_unique_constraint.sql
@@ -1,0 +1,17 @@
+-- V10__add_site_link_unique_constraint.sql
+
+-- storeName의 unique constraint 제거
+ALTER TABLE stores DROP INDEX store_name;
+
+-- 모든 링크 컬럼을 TEXT → VARCHAR(255)로 변경
+ALTER TABLE stores MODIFY COLUMN baemin_link VARCHAR(255);
+ALTER TABLE stores MODIFY COLUMN yogiyo_link VARCHAR(255);
+ALTER TABLE stores MODIFY COLUMN coupangeats_link VARCHAR(255);
+ALTER TABLE stores MODIFY COLUMN naver_map_link VARCHAR(255);
+ALTER TABLE stores MODIFY COLUMN kakao_map_link VARCHAR(255);
+ALTER TABLE stores MODIFY COLUMN instagram_link VARCHAR(255);
+ALTER TABLE stores MODIFY COLUMN kakao_talk_link VARCHAR(255);
+ALTER TABLE stores MODIFY COLUMN site_link VARCHAR(255);
+
+-- site_link에 unique constraint 추가
+ALTER TABLE stores ADD CONSTRAINT uk_site_link UNIQUE (site_link);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Naver, Kakao Map, Instagram, KakaoTalk, and site link fields in store APIs (request/response).
  - New public lookup: fetch store by site link.
  - Clear validation error when a site link is already in use.

- Refactor
  - Public endpoint path changed from /{storeName} to /{siteLink}.
  - Store name uniqueness removed; uniqueness now based on site link.

- Chores
  - Database migration: add unique constraint on site link and standardize link columns to 255 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->