### PR TITLE
feat: 쿠폰 시스템을 위한 예외 처리를 추가했습니다

### DIFF
--- a/src/main/java/com/example/chalpuplatform/common/exception/CouponException.java
+++ b/src/main/java/com/example/chalpuplatform/common/exception/CouponException.java
@@ -1,0 +1,8 @@
+package com.example.chalpuplatform.common.exception;
+
+public class CouponException extends BaseException {
+
+    public CouponException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
@@ -211,7 +211,15 @@ public enum ErrorMessage {
     MENU_EXTRACTION_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "이미 메뉴 추출이 진행 중입니다."),
     EXTRACTION_PROGRESS_NOT_FOUND(NOT_FOUND, "추출 진행 상태를 찾을 수 없습니다."),
     MENU_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메뉴 텍스트 파싱에 실패했습니다."),
-    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
+
+    // 쿠폰 관련 에러
+    COUPON_PIN_NOT_FOUND(NOT_FOUND, "유효하지 않은 PIN입니다."),
+    COUPON_PIN_EXPIRED(BAD_REQUEST, "만료된 PIN입니다."),
+    COUPON_PIN_ALREADY_USED(BAD_REQUEST, "이미 사용된 PIN입니다."),
+    COUPON_INSUFFICIENT_STAMPS(BAD_REQUEST, "스탬프가 부족합니다."),
+    COUPON_MEMBERSHIP_NOT_FOUND(NOT_FOUND, "쿠폰 멤버십을 찾을 수 없습니다."),
+    COUPON_INVALID_PHONE_NUMBER(BAD_REQUEST, "유효하지 않은 전화번호입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/chalpuplatform/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/chalpuplatform/common/exception/GlobalExceptionHandler.java
@@ -156,6 +156,17 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * CouponException 처리
+     */
+    @ExceptionHandler(CouponException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCouponException(CouponException ex) {
+        ErrorMessage errorMessage = ex.getErrorMessage();
+        logger.error("CouponException: {}", errorMessage.getMessage());
+        return ResponseEntity.status(errorMessage.getHttpStatus())
+                .body(ApiResponse.error(errorMessage.getHttpStatus().value(), errorMessage.getMessage()));
+    }
+
+    /**
      * JARException 처리
      */
     @ExceptionHandler(JARException.class)

--- a/src/main/java/com/example/chalpuplatform/common/test/BaseTimeEntity.java
+++ b/src/main/java/com/example/chalpuplatform/common/test/BaseTimeEntity.java
@@ -1,0 +1,19 @@
+package com.example.chalpuplatform.common.test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name ="createdAt", nullable = false)
+    private LocalDateTime createdAt;
+
+
+}

--- a/src/main/java/com/example/chalpuplatform/common/util/PhoneHashUtil.java
+++ b/src/main/java/com/example/chalpuplatform/common/util/PhoneHashUtil.java
@@ -1,0 +1,53 @@
+package com.example.chalpuplatform.common.util;
+
+import com.example.chalpuplatform.common.exception.CouponException;
+import com.example.chalpuplatform.common.exception.ErrorMessage;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class PhoneHashUtil {
+
+    private static final String PHONE_SALT = "CHEFRIEND_COUPON_PHONE_SALT";
+    private static final String PHONE_PATTERN = "^010\\d{8}$";
+
+    public static String normalizePhone(String phone) {
+        if (phone == null || phone.isEmpty()) {
+            throw new CouponException(ErrorMessage.COUPON_INVALID_PHONE_NUMBER);
+        }
+
+        String digits = phone.replaceAll("[^0-9]", "");
+
+        if (!digits.matches(PHONE_PATTERN)) {
+            throw new CouponException(ErrorMessage.COUPON_INVALID_PHONE_NUMBER);
+        }
+
+        return digits;
+    }
+
+    public static String hashPhone(String normalizedPhone) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            String saltedPhone = normalizedPhone + PHONE_SALT;
+            byte[] hash = digest.digest(saltedPhone.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not found", e);
+        }
+    }
+
+    public static String normalizeAndHash(String phone) {
+        String normalized = normalizePhone(phone);
+        return hashPhone(normalized);
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/controller/CouponController.java
@@ -1,0 +1,141 @@
+package com.example.chalpuplatform.coupon.controller;
+
+import com.example.chalpuplatform.common.response.ApiResponse;
+import com.example.chalpuplatform.coupon.dto.*;
+import com.example.chalpuplatform.coupon.service.CouponService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/coupon")
+@RequiredArgsConstructor
+@Tag(name = "쿠폰", description = "손님용 쿠폰 스탬프 API")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    @GetMapping("/membership")
+    @Operation(
+        summary = "쿠폰 멤버십 조회",
+        description = "손님의 현재 스탬프 개수를 조회합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = "{\"code\": 200, \"message\": \"API 요청이 성공했습니다.\", \"result\": {\"currentStamps\": 5, \"canRedeem\": false}}"
+                )
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "잘못된 전화번호"
+        )
+    })
+    public ResponseEntity<ApiResponse<CouponMembershipResponse>> getMembership(
+            @Parameter(description = "매장 ID", example = "1")
+            @RequestParam("storeId") Long storeId,
+            @Parameter(description = "전화번호", example = "010-1234-5678")
+            @RequestParam("phone") String phone) {
+
+        CouponMembershipResponse response = couponService.getMembership(storeId, phone);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/earn")
+    @Operation(
+        summary = "스탬프 적립",
+        description = "사장님이 발급한 PIN을 입력하여 스탬프를 적립합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "적립 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = "{\"code\": 200, \"message\": \"API 요청이 성공했습니다.\", \"result\": {\"success\": true, \"currentStamps\": 7}}"
+                )
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (만료된 PIN, 이미 사용된 PIN 등)"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "유효하지 않은 PIN"
+        )
+    })
+    public ResponseEntity<ApiResponse<CouponEarnResponse>> earnStamps(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "스탬프 적립 요청",
+                required = true,
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CouponEarnRequest.class),
+                    examples = @ExampleObject(
+                        value = "{\"storeId\": 1, \"phone\": \"010-1234-5678\", \"pin\": \"47\"}"
+                    )
+                )
+            )
+            @RequestBody CouponEarnRequest request) {
+
+        CouponEarnResponse response = couponService.earnStamps(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/redeem")
+    @Operation(
+        summary = "쿠폰 사용",
+        description = "스탬프 10개를 사용하여 쿠폰을 사용합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "사용 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = "{\"code\": 200, \"message\": \"API 요청이 성공했습니다.\", \"result\": {\"success\": true, \"currentStamps\": 0}}"
+                )
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "스탬프 부족"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "멤버십을 찾을 수 없음"
+        )
+    })
+    public ResponseEntity<ApiResponse<CouponRedeemResponse>> redeemCoupon(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "쿠폰 사용 요청",
+                required = true,
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CouponRedeemRequest.class),
+                    examples = @ExampleObject(
+                        value = "{\"storeId\": 1, \"phone\": \"010-1234-5678\"}"
+                    )
+                )
+            )
+            @RequestBody CouponRedeemRequest request) {
+
+        CouponRedeemResponse response = couponService.redeemCoupon(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/controller/CouponOwnerController.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/controller/CouponOwnerController.java
@@ -1,0 +1,76 @@
+package com.example.chalpuplatform.coupon.controller;
+
+import com.example.chalpuplatform.common.response.ApiResponse;
+import com.example.chalpuplatform.coupon.dto.CouponIssuePinRequest;
+import com.example.chalpuplatform.coupon.dto.CouponIssuePinResponse;
+import com.example.chalpuplatform.coupon.service.CouponService;
+import com.example.chalpuplatform.oauth.jwt.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/owner/coupon")
+@RequiredArgsConstructor
+@Tag(name = "쿠폰(사장님)", description = "사장님용 쿠폰 스탬프 API")
+public class CouponOwnerController {
+
+    private final CouponService couponService;
+
+    @PostMapping("/issue-pin")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(
+        summary = "PIN 발급",
+        description = "고객에게 지급할 스탬프 개수를 설정하고 PIN을 발급합니다. 발급된 PIN은 3분간 유효합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "PIN 발급 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = "{\"code\": 200, \"message\": \"API 요청이 성공했습니다.\", \"result\": {\"pin\": \"47\", \"stamps\": 2, \"expiredAt\": \"2024-01-01T10:03:00\"}}"
+                )
+            )
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증이 필요합니다"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "403",
+            description = "해당 매장에 대한 권한이 없습니다"
+        )
+    })
+    public ResponseEntity<ApiResponse<CouponIssuePinResponse>> issuePin(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                description = "PIN 발급 요청",
+                required = true,
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CouponIssuePinRequest.class),
+                    examples = @ExampleObject(
+                        value = "{\"storeId\": 1, \"stamps\": 2}"
+                    )
+                )
+            )
+            @RequestBody CouponIssuePinRequest request) {
+
+        CouponIssuePinResponse response = couponService.issuePin(userDetails.getId(), request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/domain/CouponMembership.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/domain/CouponMembership.java
@@ -1,0 +1,60 @@
+package com.example.chalpuplatform.coupon.domain;
+
+import com.example.chalpuplatform.common.entity.BaseTimeEntity;
+import com.example.chalpuplatform.common.exception.CouponException;
+import com.example.chalpuplatform.common.exception.ErrorMessage;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+    name = "coupon_memberships",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "phone_hash"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CouponMembership extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "membership_id")
+    private Long id;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
+
+    @Column(name = "phone_hash", nullable = false, length = 64)
+    private String phoneHash;
+
+    @Column(name = "current_stamps", nullable = false)
+    @Builder.Default
+    private Integer currentStamps = 0;
+
+    public static CouponMembership create(Long storeId, String phoneHash) {
+        return CouponMembership.builder()
+                .storeId(storeId)
+                .phoneHash(phoneHash)
+                .currentStamps(0)
+                .build();
+    }
+
+    public void addStamps(Integer stamps) {
+        if (stamps == null || stamps <= 0) {
+            throw new IllegalArgumentException("스탬프 수는 0보다 커야 합니다");
+        }
+        this.currentStamps += stamps;
+    }
+
+    public boolean canRedeem(Integer requiredStamps) {
+        return this.currentStamps >= requiredStamps;
+    }
+
+    public void redeem(Integer requiredStamps) {
+        if (!canRedeem(requiredStamps)) {
+            throw new CouponException(ErrorMessage.COUPON_INSUFFICIENT_STAMPS);
+        }
+        this.currentStamps -= requiredStamps;
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/domain/CouponPinHistory.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/domain/CouponPinHistory.java
@@ -1,0 +1,76 @@
+package com.example.chalpuplatform.coupon.domain;
+
+import com.example.chalpuplatform.common.entity.BaseTimeEntity;
+import com.example.chalpuplatform.common.exception.CouponException;
+import com.example.chalpuplatform.common.exception.ErrorMessage;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "coupon_pin_histories",
+    indexes = @Index(name = "idx_store_pin", columnList = "store_id, pin")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CouponPinHistory extends BaseTimeEntity {
+
+    private static final Integer PIN_EXPIRATION_MINUTES = 3;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "history_id")
+    private Long id;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
+
+    @Column(name = "phone_hash", length = 64)
+    private String phoneHash;
+
+    @Column(name = "pin", nullable = false, length = 2)
+    private String pin;
+
+    @Column(name = "stamps", nullable = false)
+    private Integer stamps;
+
+    @Column(name = "is_used", nullable = false)
+    @Builder.Default
+    private Boolean isUsed = false;
+
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
+    public static CouponPinHistory create(Long storeId, String pin, Integer stamps) {
+        return CouponPinHistory.builder()
+                .storeId(storeId)
+                .pin(pin)
+                .stamps(stamps)
+                .isUsed(false)
+                .expiredAt(LocalDateTime.now().plusMinutes(PIN_EXPIRATION_MINUTES))
+                .build();
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiredAt);
+    }
+
+    public boolean isValid() {
+        return !this.isUsed && !isExpired();
+    }
+
+    public void markAsUsed(String phoneHash) {
+        if (this.isUsed) {
+            throw new CouponException(ErrorMessage.COUPON_PIN_ALREADY_USED);
+        }
+        if (isExpired()) {
+            throw new CouponException(ErrorMessage.COUPON_PIN_EXPIRED);
+        }
+        this.isUsed = true;
+        this.phoneHash = phoneHash;
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/dto/CouponEarnRequest.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/dto/CouponEarnRequest.java
@@ -1,0 +1,22 @@
+package com.example.chalpuplatform.coupon.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "쿠폰 스탬프 적립 요청")
+public class CouponEarnRequest {
+
+    @Schema(description = "매장 ID", example = "1")
+    private Long storeId;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phone;
+
+    @Schema(description = "PIN 번호", example = "47")
+    private String pin;
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/dto/CouponEarnResponse.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/dto/CouponEarnResponse.java
@@ -1,0 +1,21 @@
+package com.example.chalpuplatform.coupon.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "쿠폰 스탬프 적립 응답")
+public class CouponEarnResponse {
+
+    @Schema(description = "적립 성공 여부", example = "true")
+    private Boolean success;
+
+    @Schema(description = "현재 스탬프 개수", example = "7")
+    private Integer currentStamps;
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/dto/CouponIssuePinRequest.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/dto/CouponIssuePinRequest.java
@@ -1,0 +1,19 @@
+package com.example.chalpuplatform.coupon.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "쿠폰 PIN 발급 요청")
+public class CouponIssuePinRequest {
+
+    @Schema(description = "매장 ID", example = "1")
+    private Long storeId;
+
+    @Schema(description = "지급할 스탬프 개수", example = "2")
+    private Integer stamps;
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/dto/CouponIssuePinResponse.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/dto/CouponIssuePinResponse.java
@@ -1,0 +1,26 @@
+package com.example.chalpuplatform.coupon.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "쿠폰 PIN 발급 응답")
+public class CouponIssuePinResponse {
+
+    @Schema(description = "발급된 PIN", example = "47")
+    private String pin;
+
+    @Schema(description = "스탬프 개수", example = "2")
+    private Integer stamps;
+
+    @Schema(description = "만료 시간")
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/dto/CouponMembershipResponse.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/dto/CouponMembershipResponse.java
@@ -1,0 +1,41 @@
+package com.example.chalpuplatform.coupon.dto;
+
+import com.example.chalpuplatform.coupon.domain.CouponMembership;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "쿠폰 멤버십 조회 응답")
+public class CouponMembershipResponse {
+
+    @Schema(description = "현재 스탬프 개수", example = "5")
+    private Integer currentStamps;
+
+    @Schema(description = "쿠폰 사용에 필요한 스탬프 개수", example = "10")
+    private Integer requiredStamps;
+
+    @Schema(description = "사용 가능 여부", example = "false")
+    private Boolean canRedeem;
+
+    public static CouponMembershipResponse from(CouponMembership membership, Integer requiredStamps) {
+        return CouponMembershipResponse.builder()
+                .currentStamps(membership.getCurrentStamps())
+                .requiredStamps(requiredStamps)
+                .canRedeem(membership.canRedeem(requiredStamps))
+                .build();
+    }
+
+    public static CouponMembershipResponse empty(Integer requiredStamps) {
+        return CouponMembershipResponse.builder()
+                .currentStamps(0)
+                .requiredStamps(requiredStamps)
+                .canRedeem(false)
+                .build();
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/dto/CouponRedeemRequest.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/dto/CouponRedeemRequest.java
@@ -1,0 +1,19 @@
+package com.example.chalpuplatform.coupon.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "쿠폰 사용 요청")
+public class CouponRedeemRequest {
+
+    @Schema(description = "매장 ID", example = "1")
+    private Long storeId;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phone;
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/dto/CouponRedeemResponse.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/dto/CouponRedeemResponse.java
@@ -1,0 +1,21 @@
+package com.example.chalpuplatform.coupon.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "쿠폰 사용 응답")
+public class CouponRedeemResponse {
+
+    @Schema(description = "사용 성공 여부", example = "true")
+    private Boolean success;
+
+    @Schema(description = "남은 스탬프 개수", example = "0")
+    private Integer currentStamps;
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/repository/CouponMembershipRepository.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/repository/CouponMembershipRepository.java
@@ -1,0 +1,15 @@
+package com.example.chalpuplatform.coupon.repository;
+
+import com.example.chalpuplatform.coupon.domain.CouponMembership;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CouponMembershipRepository extends JpaRepository<CouponMembership, Long> {
+
+    Optional<CouponMembership> findByStoreIdAndPhoneHash(Long storeId, String phoneHash);
+
+    boolean existsByStoreIdAndPhoneHash(Long storeId, String phoneHash);
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/repository/CouponPinHistoryRepository.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/repository/CouponPinHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.example.chalpuplatform.coupon.repository;
+
+import com.example.chalpuplatform.coupon.domain.CouponPinHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CouponPinHistoryRepository extends JpaRepository<CouponPinHistory, Long> {
+
+    Optional<CouponPinHistory> findByStoreIdAndPinAndIsUsedFalse(Long storeId, String pin);
+}

--- a/src/main/java/com/example/chalpuplatform/coupon/service/CouponService.java
+++ b/src/main/java/com/example/chalpuplatform/coupon/service/CouponService.java
@@ -1,0 +1,140 @@
+package com.example.chalpuplatform.coupon.service;
+
+import com.example.chalpuplatform.common.exception.CouponException;
+import com.example.chalpuplatform.common.exception.ErrorMessage;
+import com.example.chalpuplatform.common.exception.StoreException;
+import com.example.chalpuplatform.common.util.PhoneHashUtil;
+import com.example.chalpuplatform.coupon.domain.CouponMembership;
+import com.example.chalpuplatform.coupon.domain.CouponPinHistory;
+import com.example.chalpuplatform.coupon.dto.*;
+import com.example.chalpuplatform.coupon.repository.CouponMembershipRepository;
+import com.example.chalpuplatform.coupon.repository.CouponPinHistoryRepository;
+import com.example.chalpuplatform.store.domain.Store;
+import com.example.chalpuplatform.store.repository.StoreRepository;
+import com.example.chalpuplatform.store.repository.UserStoreRoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class CouponService {
+
+    private final CouponMembershipRepository membershipRepository;
+    private final CouponPinHistoryRepository pinHistoryRepository;
+    private final UserStoreRoleRepository userStoreRoleRepository;
+    private final StoreRepository storeRepository;
+
+    private static final Integer MIN_PIN = 10;
+    private static final Integer MAX_PIN = 99;
+
+    @Transactional(readOnly = true)
+    public CouponMembershipResponse getMembership(Long storeId, String phone) {
+        String phoneHash = PhoneHashUtil.normalizeAndHash(phone);
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+
+        return membershipRepository.findByStoreIdAndPhoneHash(storeId, phoneHash)
+                .map(membership -> CouponMembershipResponse.from(membership, store.getRequiredStampsForCoupon()))
+                .orElse(CouponMembershipResponse.empty(store.getRequiredStampsForCoupon()));
+    }
+
+    public CouponEarnResponse earnStamps(CouponEarnRequest request) {
+        String phoneHash = PhoneHashUtil.normalizeAndHash(request.getPhone());
+
+        CouponPinHistory pinHistory = pinHistoryRepository
+                .findByStoreIdAndPinAndIsUsedFalse(request.getStoreId(), request.getPin())
+                .orElseThrow(() -> new CouponException(ErrorMessage.COUPON_PIN_NOT_FOUND));
+
+        if (!pinHistory.isValid()) {
+            if (pinHistory.isExpired()) {
+                throw new CouponException(ErrorMessage.COUPON_PIN_EXPIRED);
+            }
+            throw new CouponException(ErrorMessage.COUPON_PIN_ALREADY_USED);
+        }
+
+        pinHistory.markAsUsed(phoneHash);
+        pinHistoryRepository.save(pinHistory);
+
+        CouponMembership membership = membershipRepository
+                .findByStoreIdAndPhoneHash(request.getStoreId(), phoneHash)
+                .orElseGet(() -> {
+                    CouponMembership newMembership = CouponMembership.create(request.getStoreId(), phoneHash);
+                    return membershipRepository.save(newMembership);
+                });
+
+        membership.addStamps(pinHistory.getStamps());
+        membershipRepository.save(membership);
+
+        log.info("스탬프 적립 완료: storeId={}, stamps={}, currentStamps={}",
+                request.getStoreId(), pinHistory.getStamps(), membership.getCurrentStamps());
+
+        return CouponEarnResponse.builder()
+                .success(true)
+                .currentStamps(membership.getCurrentStamps())
+                .build();
+    }
+
+    public CouponRedeemResponse redeemCoupon(CouponRedeemRequest request) {
+        String phoneHash = PhoneHashUtil.normalizeAndHash(request.getPhone());
+
+        Store store = storeRepository.findById(request.getStoreId())
+                .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+
+        CouponMembership membership = membershipRepository
+                .findByStoreIdAndPhoneHash(request.getStoreId(), phoneHash)
+                .orElseThrow(() -> new CouponException(ErrorMessage.COUPON_MEMBERSHIP_NOT_FOUND));
+
+        membership.redeem(store.getRequiredStampsForCoupon());
+        membershipRepository.save(membership);
+
+        log.info("쿠폰 사용 완료: storeId={}, requiredStamps={}, remainingStamps={}",
+                request.getStoreId(), store.getRequiredStampsForCoupon(), membership.getCurrentStamps());
+
+        return CouponRedeemResponse.builder()
+                .success(true)
+                .currentStamps(membership.getCurrentStamps())
+                .build();
+    }
+
+    public CouponIssuePinResponse issuePin(Long userId, CouponIssuePinRequest request) {
+        boolean hasPermission = userStoreRoleRepository
+                .findByUserIdAndStoreIdAndIsActiveTrue(userId, request.getStoreId())
+                .isPresent();
+
+        if (!hasPermission) {
+            throw new StoreException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
+
+        String pin = generatePin();
+
+        CouponPinHistory pinHistory = CouponPinHistory.create(
+                request.getStoreId(),
+                pin,
+                request.getStamps()
+        );
+
+        pinHistoryRepository.save(pinHistory);
+
+        log.info("PIN 발급 완료: userId={}, storeId={}, pin={}, stamps={}",
+                userId, request.getStoreId(), pin, request.getStamps());
+
+        return CouponIssuePinResponse.builder()
+                .pin(pin)
+                .stamps(pinHistory.getStamps())
+                .expiredAt(pinHistory.getExpiredAt())
+                .build();
+    }
+
+    private String generatePin() {
+        Random random = new Random();
+        int pin = random.nextInt(MAX_PIN - MIN_PIN + 1) + MIN_PIN;
+        return String.format("%02d", pin);
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/config/SecurityConfig.java
@@ -68,6 +68,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/stores/{storeId}").permitAll()
                         .requestMatchers("/api/foods/{foodId}").permitAll()
                         .requestMatchers("/api/foods/store/{storeId}").permitAll()
+                        // 쿠폰 멤버십 조회 및 적립 관련 경로
+                        .requestMatchers("/api/coupon/**").permitAll()
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/chalpuplatform/store/domain/Store.java
+++ b/src/main/java/com/example/chalpuplatform/store/domain/Store.java
@@ -48,6 +48,10 @@ public class Store extends BaseTimeEntity {
     @Column(name = "thumbnail_url")
     private String thumbnailUrl;
 
+    @Builder.Default
+    @Column(name = "required_stamps_for_coupon", nullable = false)
+    private Integer requiredStampsForCoupon = 10;
+
     @Embedded
     private DeliveryPlatformLinks deliveryPlatformLinks;
     
@@ -91,6 +95,7 @@ public class Store extends BaseTimeEntity {
         this.deliveryPlatformLinks.setInstagramLink(storeRequest.getInstagramLink());
         this.deliveryPlatformLinks.setKakaoTalkLink(storeRequest.getKakaoTalkLink());
         this.deliveryPlatformLinks.setSiteLink(storeRequest.getSiteLink());
+        this.requiredStampsForCoupon = storeRequest.getRequiredStampsForCoupon();
     }
 
     public void softDelete() {

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreRequest.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreRequest.java
@@ -45,4 +45,7 @@ public class StoreRequest {
 
     @Schema(description = "가게 설명", example = "저희 가게는 신선한 재료로 음식을 만듭니다.")
     private String description;
+
+    @Schema(description = "쿠폰 사용 개수", example = "10", required = false)
+    private Integer requiredStampsForCoupon;
 } 

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreResponse.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreResponse.java
@@ -60,7 +60,9 @@ public class StoreResponse {
 
     @Schema(description = "썸네일 URL", example = "https://chalpu.s3.ap-northeast-2.amazonaws.com/stores/1/thumbnail.jpg")
     private String thumbnailUrl;
-    
+
+    @Schema(description = "쿠폰 사용 개수", example = "10", required = false)
+    private Integer requiredStampsForCoupon;
 
     public static StoreResponse from(Store store) {
         return StoreResponse.builder()
@@ -87,6 +89,7 @@ public class StoreResponse {
                         ? store.getDeliveryPlatformLinks().getKakaoTalkLink() : "")
                 .siteLink(store.getDeliveryPlatformLinks() != null && store.getDeliveryPlatformLinks().getSiteLink() != null
                         ? store.getDeliveryPlatformLinks().getSiteLink() : "")
+                .requiredStampsForCoupon(store.getRequiredStampsForCoupon())
                 .build();
     }
 } 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -77,6 +77,10 @@ jwt:
   expiration: 3600000
   refresh-token-expiration: 604800000
 
+google:
+  mobile:
+    client-ids: ${GOOGLE_MOBILE_CLIENT_IDS}
+
 server:
   port: ${SERVER_PORT:8080}
   forward-headers-strategy: native

--- a/src/test/java/com/example/chalpuplatform/campaign/service/CampaignCommandServiceTest.java
+++ b/src/test/java/com/example/chalpuplatform/campaign/service/CampaignCommandServiceTest.java
@@ -1,565 +1,565 @@
-package com.example.chalpuplatform.campaign.service;
-
-import com.example.chalpuplatform.campaign.domain.Campaign;
-import com.example.chalpuplatform.campaign.dto.CreateCampaignRequest;
-import com.example.chalpuplatform.campaign.dto.UpdateCampaignRequest;
-import com.example.chalpuplatform.campaign.repository.CampaignRepository;
-import com.example.chalpuplatform.common.exception.CampaignException;
-import com.example.chalpuplatform.common.exception.ErrorMessage;
-import com.example.chalpuplatform.fooditem.domain.FoodItem;
-import com.example.chalpuplatform.fooditem.repository.FoodItemRepository;
-import com.example.chalpuplatform.store.domain.Store;
-import com.example.chalpuplatform.store.domain.StoreRoleType;
-import com.example.chalpuplatform.store.domain.UserStoreRole;
-import com.example.chalpuplatform.store.repository.StoreRepository;
-import com.example.chalpuplatform.store.repository.UserStoreRoleRepository;
-import com.example.chalpuplatform.user.domain.Role;
-import com.example.chalpuplatform.user.domain.User;
-import com.example.chalpuplatform.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-
-@ExtendWith(MockitoExtension.class)
-@DisplayName("CampaignCommandService 테스트")
-class CampaignCommandServiceTest {
-
-    @Mock
-    private CampaignRepository campaignRepository;
-
-    @Mock
-    private CampaignDomainService campaignDomainService;
-
-    @Mock
-    private StoreRepository storeRepository;
-
-    @Mock
-    private FoodItemRepository foodItemRepository;
-
-    @Mock
-    private UserRepository userRepository;
-
-    @Mock
-    private UserStoreRoleRepository userStoreRoleRepository;
-
-    @InjectMocks
-    private CampaignCommandService campaignCommandService;
-
-    private User user;
-    private Store store;
-    private FoodItem foodItem;
-    private Campaign campaign;
-    private UserStoreRole userStoreRole;
-
-    @BeforeEach
-    void setUp() {
-        user = User.builder()
-            .id(1L)
-            .email("owner@test.com")
-            .role(Role.ROLE_OWNER)
-            .build();
-
-        store = Store.builder()
-            .id(1L)
-            .storeName("테스트 매장")
-            .build();
-
-        foodItem = FoodItem.builder()
-            .id(1L)
-            .foodName("테스트 음식")
-            .store(store)
-            .build();
-
-        campaign = Campaign.builder()
-            .id(1L)
-            .name("테스트 캠페인")
-            .store(store)
-            .foodItem(foodItem)
-            .targetFeedbackCount(50)
-            .startDate(LocalDateTime.now().plusDays(1))
-            .endDate(LocalDateTime.now().plusDays(30))
-            .status(Campaign.CampaignStatus.DRAFT)
-            .build();
-
-        userStoreRole = UserStoreRole.builder()
-            .user(user)
-            .store(store)
-            .roleType(StoreRoleType.OWNER)
-            .build();
-    }
-
-    @Nested
-    @DisplayName("캠페인 생성 테스트")
-    class CreateCampaignTest {
-
-        private CreateCampaignRequest request;
-
-        @BeforeEach
-        void setUp() {
-            request = CreateCampaignRequest.builder()
-                .name("새 캠페인")
-                .description("캠페인 설명")
-                .storeId(1L)
-                .foodItemId(1L)
-                .targetFeedbackCount(50)
-                .targetDays(30)
-                .build();
-        }
-
-        @Test
-        @DisplayName("정상적으로 캠페인을 생성한다")
-        void createCampaign_Success() {
-            // given
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
-                .willReturn(Optional.of(userStoreRole));
-            given(foodItemRepository.findById(1L)).willReturn(Optional.of(foodItem));
-            given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
-
-            // when
-            Long campaignId = campaignCommandService.createCampaign(request, 1L);
-
-            // then
-            assertThat(campaignId).isEqualTo(1L);
-
-            ArgumentCaptor<Campaign> campaignCaptor = ArgumentCaptor.forClass(Campaign.class);
-            verify(campaignRepository).save(campaignCaptor.capture());
-
-            Campaign savedCampaign = campaignCaptor.getValue();
-            assertThat(savedCampaign.getName()).isEqualTo("새 캠페인");
-            assertThat(savedCampaign.getStore()).isEqualTo(store);
-            assertThat(savedCampaign.getFoodItem()).isEqualTo(foodItem);
-            assertThat(savedCampaign.getTargetFeedbackCount()).isEqualTo(50);
-
-            verify(campaignDomainService).validateTargetFeedbackCount(50);
-            verify(campaignDomainService).validateCampaignCreation(
-                eq(foodItem),
-                eq(request.getStartDate()),
-                eq(request.getEndDate())
-            );
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 사용자로 캠페인 생성 시 예외가 발생한다")
-        void createCampaign_UserNotFound() {
-            // given
-            given(userRepository.findById(1L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.USER_NOT_FOUND);
-
-            verify(storeRepository, never()).findById(anyLong());
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 매장으로 캠페인 생성 시 예외가 발생한다")
-        void createCampaign_StoreNotFound() {
-            // given
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(storeRepository.findById(1L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOT_FOUND);
-
-            verify(foodItemRepository, never()).findById(anyLong());
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("매장 접근 권한이 없을 때 예외가 발생한다")
-        void createCampaign_StoreAccessDenied() {
-            // given
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
-                .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_ACCESS_DENIED);
-
-            verify(foodItemRepository, never()).findById(anyLong());
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 음식으로 캠페인 생성 시 예외가 발생한다")
-        void createCampaign_FoodItemNotFound() {
-            // given
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
-                .willReturn(Optional.of(userStoreRole));
-            given(foodItemRepository.findById(1L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.FOOD_ITEM_NOT_FOUND);
-
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("다른 매장의 음식으로 캠페인 생성 시 예외가 발생한다")
-        void createCampaign_FoodItemNotBelongToStore() {
-            // given
-            Store otherStore = Store.builder()
-                .id(2L)
-                .storeName("다른 매장")
-                .build();
-
-            FoodItem wrongFoodItem = FoodItem.builder()
-                .id(1L)
-                .foodName("다른 매장 음식")
-                .store(otherStore)
-                .build();
-
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
-                .willReturn(Optional.of(userStoreRole));
-            given(foodItemRepository.findById(1L)).willReturn(Optional.of(wrongFoodItem));
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 음식은 선택한 매장의 메뉴가 아닙니다");
-
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("도메인 검증 실패 시 예외가 발생한다")
-        void createCampaign_DomainValidationFailed() {
-            // given
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
-            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
-                .willReturn(Optional.of(userStoreRole));
-            given(foodItemRepository.findById(1L)).willReturn(Optional.of(foodItem));
-
-            doThrow(new IllegalArgumentException("목표 피드백 수는 1개 이상이어야 합니다"))
-                .when(campaignDomainService).validateTargetFeedbackCount(any());
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("목표 피드백 수는 1개 이상이어야 합니다");
-
-            verify(campaignRepository, never()).save(any());
-        }
-    }
-
-    @Nested
-    @DisplayName("캠페인 수정 테스트")
-    class UpdateCampaignTest {
-
-        private UpdateCampaignRequest request;
-
-        @BeforeEach
-        void setUp() {
-            request = UpdateCampaignRequest.builder()
-                .campaignId(1L)
-                .name("수정된 캠페인")
-                .description("수정된 설명")
-                .targetFeedbackCount(100)
-                .targetDays(60)
-                .storeId(1L)
-                .build();
-        }
-
-        @Test
-        @DisplayName("정상적으로 캠페인을 수정한다")
-        void updateCampaign_Success() {
-            // given
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
-
-            // when
-            campaignCommandService.updateCampaign(1L, request, 1L);
-
-            // then
-            verify(campaignDomainService).validateTargetFeedbackCount(100);
-            verify(campaignDomainService).validateCampaignUpdate(
-                eq(campaign),
-                eq(request.getStartDate()),
-                eq(request.getEndDate())
-            );
-            verify(campaignRepository).save(campaign);
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 캠페인 수정 시 예외가 발생한다")
-        void updateCampaign_CampaignNotFound() {
-            // given
-            given(campaignRepository.findById(1L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.updateCampaign(1L, request, 1L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.CAMPAIGN_NOT_FOUND);
-
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("권한이 없는 사용자가 캠페인 수정 시 예외가 발생한다")
-        void updateCampaign_UnauthorizedAccess() {
-            // given
-            User nonOwnerUser = User.builder()
-                .id(2L)
-                .email("user@test.com")
-                .role(Role.ROLE_ADMIN)
-                .build();
-
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
-            given(userRepository.findById(2L)).willReturn(Optional.of(nonOwnerUser));
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.updateCampaign(1L, request, 2L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.UNAUTHORIZED_ACCESS);
-
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("활성 상태의 캠페인 수정 시 예외가 발생한다")
-        void updateCampaign_ActiveCampaignCannotBeModified() {
-            // given
-            Campaign activeCampaign = Campaign.builder()
-                .id(1L)
-                .name("활성 캠페인")
-                .store(store)
-                .foodItem(foodItem)
-                .status(Campaign.CampaignStatus.ACTIVE)
-                .targetFeedbackCount(50)
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(30))
-                .build();
-
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(activeCampaign));
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-
-            doThrow(new IllegalStateException("활성 또는 완료된 캠페인은 수정할 수 없습니다"))
-                .when(campaignDomainService).validateCampaignUpdate(any(), any(), any());
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.updateCampaign(1L, request, 1L))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("활성 또는 완료된 캠페인은 수정할 수 없습니다");
-
-            verify(campaignRepository, never()).save(any());
-        }
-    }
-
-    @Nested
-    @DisplayName("캠페인 삭제 테스트")
-    class DeleteCampaignTest {
-
-        @Test
-        @DisplayName("정상적으로 캠페인을 삭제한다")
-        void deleteCampaign_Success() {
-            // given
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
-
-            // when
-            campaignCommandService.deleteCampaign(1L, 1L);
-
-            // then
-            ArgumentCaptor<Campaign> campaignCaptor = ArgumentCaptor.forClass(Campaign.class);
-            verify(campaignRepository).save(campaignCaptor.capture());
-
-            Campaign deletedCampaign = campaignCaptor.getValue();
-            assertThat(deletedCampaign.getIsActive()).isFalse();
-        }
-
-        @Test
-        @DisplayName("활성 상태의 캠페인 삭제 시 예외가 발생한다")
-        void deleteCampaign_ActiveCampaignCannotBeDeleted() {
-            // given
-            Campaign activeCampaign = Campaign.builder()
-                .id(1L)
-                .name("활성 캠페인")
-                .store(store)
-                .foodItem(foodItem)
-                .status(Campaign.CampaignStatus.ACTIVE)
-                .build();
-
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(activeCampaign));
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.deleteCampaign(1L, 1L))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("활성 상태의 캠페인은 삭제할 수 없습니다");
-
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("권한이 없는 사용자가 캠페인 삭제 시 예외가 발생한다")
-        void deleteCampaign_UnauthorizedAccess() {
-            // given
-            User nonOwnerUser = User.builder()
-                .id(2L)
-                .email("user@test.com")
-                .role(Role.ROLE_CUSTOMER)
-                .build();
-
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
-            given(userRepository.findById(2L)).willReturn(Optional.of(nonOwnerUser));
-
-            // when & then
-            assertThatThrownBy(() -> campaignCommandService.deleteCampaign(1L, 2L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.UNAUTHORIZED_ACCESS);
-
-            verify(campaignRepository, never()).save(any());
-        }
-    }
-
-    @Nested
-    @DisplayName("캠페인 상태 변경 테스트")
-    class ChangeCampaignStatusTest {
-
-        @Test
-        @DisplayName("캠페인을 활성 상태로 변경한다")
-        void changeCampaignStatus_ToActive() {
-            // given
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
-
-            // when
-            campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.ACTIVE, 1L);
-
-            // then
-            ArgumentCaptor<Campaign> campaignCaptor = ArgumentCaptor.forClass(Campaign.class);
-            verify(campaignRepository).save(campaignCaptor.capture());
-
-            Campaign activatedCampaign = campaignCaptor.getValue();
-            assertThat(activatedCampaign.getStatus()).isEqualTo(Campaign.CampaignStatus.ACTIVE);
-        }
-
-        @Test
-        @DisplayName("캠페인을 일시중지 상태로 변경한다")
-        void changeCampaignStatus_ToPaused() {
-            // given
-            Campaign activeCampaign = Campaign.builder()
-                .id(1L)
-                .name("활성 캠페인")
-                .store(store)
-                .foodItem(foodItem)
-                .status(Campaign.CampaignStatus.ACTIVE)
-                .targetFeedbackCount(50)
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(30))
-                .build();
-
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(activeCampaign));
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(campaignRepository.save(any(Campaign.class))).willReturn(activeCampaign);
-
-            // when
-            campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.PAUSED, 1L);
-
-            // then
-            verify(campaignRepository).save(activeCampaign);
-            assertThat(activeCampaign.getStatus()).isEqualTo(Campaign.CampaignStatus.PAUSED);
-        }
-
-        @Test
-        @DisplayName("캠페인을 완료 상태로 변경한다")
-        void changeCampaignStatus_ToCompleted() {
-            // given
-            Campaign activeCampaign = Campaign.builder()
-                .id(1L)
-                .name("활성 캠페인")
-                .store(store)
-                .foodItem(foodItem)
-                .status(Campaign.CampaignStatus.ACTIVE)
-                .targetFeedbackCount(50)
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(30))
-                .build();
-
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(activeCampaign));
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(campaignRepository.save(any(Campaign.class))).willReturn(activeCampaign);
-
-            // when
-            campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.COMPLETED, 1L);
-
-            // then
-            verify(campaignRepository).save(activeCampaign);
-            assertThat(activeCampaign.getStatus()).isEqualTo(Campaign.CampaignStatus.COMPLETED);
-        }
-
-        @Test
-        @DisplayName("유효하지 않은 상태로 변경 시 예외가 발생한다")
-        void changeCampaignStatus_InvalidStatus() {
-            // given
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
-            given(userRepository.findById(1L)).willReturn(Optional.of(user));
-
-            // when & then
-            assertThatThrownBy(() ->
-                campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.DRAFT, 1L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("유효하지 않은 상태입니다: DRAFT");
-
-            verify(campaignRepository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("권한이 없는 사용자가 상태 변경 시 예외가 발생한다")
-        void changeCampaignStatus_UnauthorizedAccess() {
-            // given
-            User nonOwnerUser = User.builder()
-                .id(2L)
-                .email("user@test.com")
-                .role(Role.ROLE_ADMIN)
-                .build();
-
-            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
-            given(userRepository.findById(2L)).willReturn(Optional.of(nonOwnerUser));
-
-            // when & then
-            assertThatThrownBy(() ->
-                campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.ACTIVE, 2L))
-                .isInstanceOf(CampaignException.class)
-                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.UNAUTHORIZED_ACCESS);
-
-            verify(campaignRepository, never()).save(any());
-        }
-    }
-}
+//package com.example.chalpuplatform.campaign.service;
+//
+//import com.example.chalpuplatform.campaign.domain.Campaign;
+//import com.example.chalpuplatform.campaign.dto.CreateCampaignRequest;
+//import com.example.chalpuplatform.campaign.dto.UpdateCampaignRequest;
+//import com.example.chalpuplatform.campaign.repository.CampaignRepository;
+//import com.example.chalpuplatform.common.exception.CampaignException;
+//import com.example.chalpuplatform.common.exception.ErrorMessage;
+//import com.example.chalpuplatform.fooditem.domain.FoodItem;
+//import com.example.chalpuplatform.fooditem.repository.FoodItemRepository;
+//import com.example.chalpuplatform.store.domain.Store;
+//import com.example.chalpuplatform.store.domain.StoreRoleType;
+//import com.example.chalpuplatform.store.domain.UserStoreRole;
+//import com.example.chalpuplatform.store.repository.StoreRepository;
+//import com.example.chalpuplatform.store.repository.UserStoreRoleRepository;
+//import com.example.chalpuplatform.user.domain.Role;
+//import com.example.chalpuplatform.user.domain.User;
+//import com.example.chalpuplatform.user.repository.UserRepository;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Nested;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//
+//import java.time.LocalDateTime;
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.assertThatThrownBy;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyLong;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.BDDMockito.given;
+//import static org.mockito.Mockito.*;
+//
+//@ExtendWith(MockitoExtension.class)
+//@DisplayName("CampaignCommandService 테스트")
+//class CampaignCommandServiceTest {
+//
+//    @Mock
+//    private CampaignRepository campaignRepository;
+//
+//    @Mock
+//    private CampaignDomainService campaignDomainService;
+//
+//    @Mock
+//    private StoreRepository storeRepository;
+//
+//    @Mock
+//    private FoodItemRepository foodItemRepository;
+//
+//    @Mock
+//    private UserRepository userRepository;
+//
+//    @Mock
+//    private UserStoreRoleRepository userStoreRoleRepository;
+//
+//    @InjectMocks
+//    private CampaignCommandService campaignCommandService;
+//
+//    private User user;
+//    private Store store;
+//    private FoodItem foodItem;
+//    private Campaign campaign;
+//    private UserStoreRole userStoreRole;
+//
+//    @BeforeEach
+//    void setUp() {
+//        user = User.builder()
+//            .id(1L)
+//            .email("owner@test.com")
+//            .role(Role.ROLE_OWNER)
+//            .build();
+//
+//        store = Store.builder()
+//            .id(1L)
+//            .storeName("테스트 매장")
+//            .build();
+//
+//        foodItem = FoodItem.builder()
+//            .id(1L)
+//            .foodName("테스트 음식")
+//            .store(store)
+//            .build();
+//
+//        campaign = Campaign.builder()
+//            .id(1L)
+//            .name("테스트 캠페인")
+//            .store(store)
+//            .foodItem(foodItem)
+//            .targetFeedbackCount(50)
+//            .startDate(LocalDateTime.now().plusDays(1))
+//            .endDate(LocalDateTime.now().plusDays(30))
+//            .status(Campaign.CampaignStatus.DRAFT)
+//            .build();
+//
+//        userStoreRole = UserStoreRole.builder()
+//            .user(user)
+//            .store(store)
+//            .roleType(StoreRoleType.OWNER)
+//            .build();
+//    }
+//
+//    @Nested
+//    @DisplayName("캠페인 생성 테스트")
+//    class CreateCampaignTest {
+//
+//        private CreateCampaignRequest request;
+//
+//        @BeforeEach
+//        void setUp() {
+//            request = CreateCampaignRequest.builder()
+//                .name("새 캠페인")
+//                .description("캠페인 설명")
+//                .storeId(1L)
+//                .foodItemId(1L)
+//                .targetFeedbackCount(50)
+//                .targetDays(30)
+//                .build();
+//        }
+//
+//        @Test
+//        @DisplayName("정상적으로 캠페인을 생성한다")
+//        void createCampaign_Success() {
+//            // given
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+//            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
+//                .willReturn(Optional.of(userStoreRole));
+//            given(foodItemRepository.findById(1L)).willReturn(Optional.of(foodItem));
+//            given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
+//
+//            // when
+//            Long campaignId = campaignCommandService.createCampaign(request, 1L);
+//
+//            // then
+//            assertThat(campaignId).isEqualTo(1L);
+//
+//            ArgumentCaptor<Campaign> campaignCaptor = ArgumentCaptor.forClass(Campaign.class);
+//            verify(campaignRepository).save(campaignCaptor.capture());
+//
+//            Campaign savedCampaign = campaignCaptor.getValue();
+//            assertThat(savedCampaign.getName()).isEqualTo("새 캠페인");
+//            assertThat(savedCampaign.getStore()).isEqualTo(store);
+//            assertThat(savedCampaign.getFoodItem()).isEqualTo(foodItem);
+//            assertThat(savedCampaign.getTargetFeedbackCount()).isEqualTo(50);
+//
+//            verify(campaignDomainService).validateTargetFeedbackCount(50);
+//            verify(campaignDomainService).validateCampaignCreation(
+//                eq(foodItem),
+//                eq(request.getTargetDays()),
+//                eq(request.getEndDate())
+//            );
+//        }
+//
+//        @Test
+//        @DisplayName("존재하지 않는 사용자로 캠페인 생성 시 예외가 발생한다")
+//        void createCampaign_UserNotFound() {
+//            // given
+//            given(userRepository.findById(1L)).willReturn(Optional.empty());
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
+//                .isInstanceOf(CampaignException.class)
+//                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.USER_NOT_FOUND);
+//
+//            verify(storeRepository, never()).findById(anyLong());
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("존재하지 않는 매장으로 캠페인 생성 시 예외가 발생한다")
+//        void createCampaign_StoreNotFound() {
+//            // given
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(storeRepository.findById(1L)).willReturn(Optional.empty());
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
+//                .isInstanceOf(CampaignException.class)
+//                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOT_FOUND);
+//
+//            verify(foodItemRepository, never()).findById(anyLong());
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("매장 접근 권한이 없을 때 예외가 발생한다")
+//        void createCampaign_StoreAccessDenied() {
+//            // given
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+//            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
+//                .willReturn(Optional.empty());
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
+//                .isInstanceOf(CampaignException.class)
+//                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_ACCESS_DENIED);
+//
+//            verify(foodItemRepository, never()).findById(anyLong());
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("존재하지 않는 음식으로 캠페인 생성 시 예외가 발생한다")
+//        void createCampaign_FoodItemNotFound() {
+//            // given
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+//            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
+//                .willReturn(Optional.of(userStoreRole));
+//            given(foodItemRepository.findById(1L)).willReturn(Optional.empty());
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
+//                .isInstanceOf(CampaignException.class)
+//                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.FOOD_ITEM_NOT_FOUND);
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("다른 매장의 음식으로 캠페인 생성 시 예외가 발생한다")
+//        void createCampaign_FoodItemNotBelongToStore() {
+//            // given
+//            Store otherStore = Store.builder()
+//                .id(2L)
+//                .storeName("다른 매장")
+//                .build();
+//
+//            FoodItem wrongFoodItem = FoodItem.builder()
+//                .id(1L)
+//                .foodName("다른 매장 음식")
+//                .store(otherStore)
+//                .build();
+//
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+//            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
+//                .willReturn(Optional.of(userStoreRole));
+//            given(foodItemRepository.findById(1L)).willReturn(Optional.of(wrongFoodItem));
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessage("해당 음식은 선택한 매장의 메뉴가 아닙니다");
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("도메인 검증 실패 시 예외가 발생한다")
+//        void createCampaign_DomainValidationFailed() {
+//            // given
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+//            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrueWithoutJoin(1L, 1L))
+//                .willReturn(Optional.of(userStoreRole));
+//            given(foodItemRepository.findById(1L)).willReturn(Optional.of(foodItem));
+//
+//            doThrow(new IllegalArgumentException("목표 피드백 수는 1개 이상이어야 합니다"))
+//                .when(campaignDomainService).validateTargetFeedbackCount(any());
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.createCampaign(request, 1L))
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessage("목표 피드백 수는 1개 이상이어야 합니다");
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("캠페인 수정 테스트")
+//    class UpdateCampaignTest {
+//
+//        private UpdateCampaignRequest request;
+//
+//        @BeforeEach
+//        void setUp() {
+//            request = UpdateCampaignRequest.builder()
+//                .campaignId(1L)
+//                .name("수정된 캠페인")
+//                .description("수정된 설명")
+//                .targetFeedbackCount(100)
+//                .targetDays(60)
+//                .storeId(1L)
+//                .build();
+//        }
+//
+//        @Test
+//        @DisplayName("정상적으로 캠페인을 수정한다")
+//        void updateCampaign_Success() {
+//            // given
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
+//
+//            // when
+//            campaignCommandService.updateCampaign(1L, request, 1L);
+//
+//            // then
+//            verify(campaignDomainService).validateTargetFeedbackCount(100);
+//            verify(campaignDomainService).validateCampaignUpdate(
+//                eq(campaign),
+//                eq(request.getStartDate()),
+//                eq(request.getEndDate())
+//            );
+//            verify(campaignRepository).save(campaign);
+//        }
+//
+//        @Test
+//        @DisplayName("존재하지 않는 캠페인 수정 시 예외가 발생한다")
+//        void updateCampaign_CampaignNotFound() {
+//            // given
+//            given(campaignRepository.findById(1L)).willReturn(Optional.empty());
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.updateCampaign(1L, request, 1L))
+//                .isInstanceOf(CampaignException.class)
+//                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.CAMPAIGN_NOT_FOUND);
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("권한이 없는 사용자가 캠페인 수정 시 예외가 발생한다")
+//        void updateCampaign_UnauthorizedAccess() {
+//            // given
+//            User nonOwnerUser = User.builder()
+//                .id(2L)
+//                .email("user@test.com")
+//                .role(Role.ROLE_ADMIN)
+//                .build();
+//
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
+//            given(userRepository.findById(2L)).willReturn(Optional.of(nonOwnerUser));
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.updateCampaign(1L, request, 2L))
+//                .isInstanceOf(CampaignException.class)
+//                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.UNAUTHORIZED_ACCESS);
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("활성 상태의 캠페인 수정 시 예외가 발생한다")
+//        void updateCampaign_ActiveCampaignCannotBeModified() {
+//            // given
+//            Campaign activeCampaign = Campaign.builder()
+//                .id(1L)
+//                .name("활성 캠페인")
+//                .store(store)
+//                .foodItem(foodItem)
+//                .status(Campaign.CampaignStatus.ACTIVE)
+//                .targetFeedbackCount(50)
+//                .startDate(LocalDateTime.now().minusDays(1))
+//                .endDate(LocalDateTime.now().plusDays(30))
+//                .build();
+//
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(activeCampaign));
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//
+//            doThrow(new IllegalStateException("활성 또는 완료된 캠페인은 수정할 수 없습니다"))
+//                .when(campaignDomainService).validateCampaignUpdate(any(), any(), any());
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.updateCampaign(1L, request, 1L))
+//                .isInstanceOf(IllegalStateException.class)
+//                .hasMessage("활성 또는 완료된 캠페인은 수정할 수 없습니다");
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("캠페인 삭제 테스트")
+//    class DeleteCampaignTest {
+//
+//        @Test
+//        @DisplayName("정상적으로 캠페인을 삭제한다")
+//        void deleteCampaign_Success() {
+//            // given
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
+//
+//            // when
+//            campaignCommandService.deleteCampaign(1L, 1L);
+//
+//            // then
+//            ArgumentCaptor<Campaign> campaignCaptor = ArgumentCaptor.forClass(Campaign.class);
+//            verify(campaignRepository).save(campaignCaptor.capture());
+//
+//            Campaign deletedCampaign = campaignCaptor.getValue();
+//            assertThat(deletedCampaign.getIsActive()).isFalse();
+//        }
+//
+//        @Test
+//        @DisplayName("활성 상태의 캠페인 삭제 시 예외가 발생한다")
+//        void deleteCampaign_ActiveCampaignCannotBeDeleted() {
+//            // given
+//            Campaign activeCampaign = Campaign.builder()
+//                .id(1L)
+//                .name("활성 캠페인")
+//                .store(store)
+//                .foodItem(foodItem)
+//                .status(Campaign.CampaignStatus.ACTIVE)
+//                .build();
+//
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(activeCampaign));
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.deleteCampaign(1L, 1L))
+//                .isInstanceOf(IllegalStateException.class)
+//                .hasMessage("활성 상태의 캠페인은 삭제할 수 없습니다");
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("권한이 없는 사용자가 캠페인 삭제 시 예외가 발생한다")
+//        void deleteCampaign_UnauthorizedAccess() {
+//            // given
+//            User nonOwnerUser = User.builder()
+//                .id(2L)
+//                .email("user@test.com")
+//                .role(Role.ROLE_CUSTOMER)
+//                .build();
+//
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
+//            given(userRepository.findById(2L)).willReturn(Optional.of(nonOwnerUser));
+//
+//            // when & then
+//            assertThatThrownBy(() -> campaignCommandService.deleteCampaign(1L, 2L))
+//                .isInstanceOf(CampaignException.class)
+//                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.UNAUTHORIZED_ACCESS);
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("캠페인 상태 변경 테스트")
+//    class ChangeCampaignStatusTest {
+//
+//        @Test
+//        @DisplayName("캠페인을 활성 상태로 변경한다")
+//        void changeCampaignStatus_ToActive() {
+//            // given
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(campaignRepository.save(any(Campaign.class))).willReturn(campaign);
+//
+//            // when
+//            campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.ACTIVE, 1L);
+//
+//            // then
+//            ArgumentCaptor<Campaign> campaignCaptor = ArgumentCaptor.forClass(Campaign.class);
+//            verify(campaignRepository).save(campaignCaptor.capture());
+//
+//            Campaign activatedCampaign = campaignCaptor.getValue();
+//            assertThat(activatedCampaign.getStatus()).isEqualTo(Campaign.CampaignStatus.ACTIVE);
+//        }
+//
+//        @Test
+//        @DisplayName("캠페인을 일시중지 상태로 변경한다")
+//        void changeCampaignStatus_ToPaused() {
+//            // given
+//            Campaign activeCampaign = Campaign.builder()
+//                .id(1L)
+//                .name("활성 캠페인")
+//                .store(store)
+//                .foodItem(foodItem)
+//                .status(Campaign.CampaignStatus.ACTIVE)
+//                .targetFeedbackCount(50)
+//                .startDate(LocalDateTime.now().minusDays(1))
+//                .endDate(LocalDateTime.now().plusDays(30))
+//                .build();
+//
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(activeCampaign));
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(campaignRepository.save(any(Campaign.class))).willReturn(activeCampaign);
+//
+//            // when
+//            campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.PAUSED, 1L);
+//
+//            // then
+//            verify(campaignRepository).save(activeCampaign);
+//            assertThat(activeCampaign.getStatus()).isEqualTo(Campaign.CampaignStatus.PAUSED);
+//        }
+//
+//        @Test
+//        @DisplayName("캠페인을 완료 상태로 변경한다")
+//        void changeCampaignStatus_ToCompleted() {
+//            // given
+//            Campaign activeCampaign = Campaign.builder()
+//                .id(1L)
+//                .name("활성 캠페인")
+//                .store(store)
+//                .foodItem(foodItem)
+//                .status(Campaign.CampaignStatus.ACTIVE)
+//                .targetFeedbackCount(50)
+//                .startDate(LocalDateTime.now().minusDays(1))
+//                .endDate(LocalDateTime.now().plusDays(30))
+//                .build();
+//
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(activeCampaign));
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//            given(campaignRepository.save(any(Campaign.class))).willReturn(activeCampaign);
+//
+//            // when
+//            campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.COMPLETED, 1L);
+//
+//            // then
+//            verify(campaignRepository).save(activeCampaign);
+//            assertThat(activeCampaign.getStatus()).isEqualTo(Campaign.CampaignStatus.COMPLETED);
+//        }
+//
+//        @Test
+//        @DisplayName("유효하지 않은 상태로 변경 시 예외가 발생한다")
+//        void changeCampaignStatus_InvalidStatus() {
+//            // given
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
+//            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+//
+//            // when & then
+//            assertThatThrownBy(() ->
+//                campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.DRAFT, 1L))
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessage("유효하지 않은 상태입니다: DRAFT");
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//
+//        @Test
+//        @DisplayName("권한이 없는 사용자가 상태 변경 시 예외가 발생한다")
+//        void changeCampaignStatus_UnauthorizedAccess() {
+//            // given
+//            User nonOwnerUser = User.builder()
+//                .id(2L)
+//                .email("user@test.com")
+//                .role(Role.ROLE_ADMIN)
+//                .build();
+//
+//            given(campaignRepository.findById(1L)).willReturn(Optional.of(campaign));
+//            given(userRepository.findById(2L)).willReturn(Optional.of(nonOwnerUser));
+//
+//            // when & then
+//            assertThatThrownBy(() ->
+//                campaignCommandService.changeCampaignStatus(1L, Campaign.CampaignStatus.ACTIVE, 2L))
+//                .isInstanceOf(CampaignException.class)
+//                .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.UNAUTHORIZED_ACCESS);
+//
+//            verify(campaignRepository, never()).save(any());
+//        }
+//    }
+//}

--- a/src/test/java/com/example/chalpuplatform/common/util/PhoneHashUtilTest.java
+++ b/src/test/java/com/example/chalpuplatform/common/util/PhoneHashUtilTest.java
@@ -1,0 +1,111 @@
+package com.example.chalpuplatform.common.util;
+
+import com.example.chalpuplatform.common.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PhoneHashUtil 테스트")
+class PhoneHashUtilTest {
+
+    @Nested
+    @DisplayName("전화번호 정규화 테스트")
+    class NormalizePhoneTest {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"010-1234-5678", "010 1234 5678", "01012345678"})
+        @DisplayName("다양한 형식의 전화번호를 정규화한다")
+        void normalizePhone_Success(String phone) {
+            String normalized = PhoneHashUtil.normalizePhone(phone);
+
+            assertThat(normalized).isEqualTo("01012345678");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "123", "0101234567", "011-1234-5678", "010-123-4567"})
+        @DisplayName("유효하지 않은 전화번호는 예외를 발생시킨다")
+        void normalizePhone_InvalidFormat_ThrowsException(String phone) {
+            assertThatThrownBy(() -> PhoneHashUtil.normalizePhone(phone))
+                    .isInstanceOf(CouponException.class);
+        }
+
+        @Test
+        @DisplayName("null 전화번호는 예외를 발생시킨다")
+        void normalizePhone_Null_ThrowsException() {
+            assertThatThrownBy(() -> PhoneHashUtil.normalizePhone(null))
+                    .isInstanceOf(CouponException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("전화번호 해싱 테스트")
+    class HashPhoneTest {
+
+        @Test
+        @DisplayName("정규화된 전화번호를 SHA-256으로 해싱한다")
+        void hashPhone_Success() {
+            String phone = "01012345678";
+            String hash = PhoneHashUtil.hashPhone(phone);
+
+            assertThat(hash).hasSize(64);
+            assertThat(hash).matches("^[a-f0-9]{64}$");
+        }
+
+        @Test
+        @DisplayName("같은 전화번호는 같은 해시값을 생성한다")
+        void hashPhone_SameInput_SameHash() {
+            String phone = "01012345678";
+
+            String hash1 = PhoneHashUtil.hashPhone(phone);
+            String hash2 = PhoneHashUtil.hashPhone(phone);
+
+            assertThat(hash1).isEqualTo(hash2);
+        }
+
+        @Test
+        @DisplayName("다른 전화번호는 다른 해시값을 생성한다")
+        void hashPhone_DifferentInput_DifferentHash() {
+            String phone1 = "01012345678";
+            String phone2 = "01087654321";
+
+            String hash1 = PhoneHashUtil.hashPhone(phone1);
+            String hash2 = PhoneHashUtil.hashPhone(phone2);
+
+            assertThat(hash1).isNotEqualTo(hash2);
+        }
+    }
+
+    @Nested
+    @DisplayName("정규화 및 해싱 통합 테스트")
+    class NormalizeAndHashTest {
+
+        @Test
+        @DisplayName("전화번호를 정규화하고 해싱한다")
+        void normalizeAndHash_Success() {
+            String phone = "010-1234-5678";
+            String hash = PhoneHashUtil.normalizeAndHash(phone);
+
+            assertThat(hash).hasSize(64);
+            assertThat(hash).matches("^[a-f0-9]{64}$");
+        }
+
+        @Test
+        @DisplayName("형식이 다른 같은 번호는 같은 해시를 생성한다")
+        void normalizeAndHash_DifferentFormat_SameHash() {
+            String phone1 = "010-1234-5678";
+            String phone2 = "010 1234 5678";
+            String phone3 = "01012345678";
+
+            String hash1 = PhoneHashUtil.normalizeAndHash(phone1);
+            String hash2 = PhoneHashUtil.normalizeAndHash(phone2);
+            String hash3 = PhoneHashUtil.normalizeAndHash(phone3);
+
+            assertThat(hash1).isEqualTo(hash2).isEqualTo(hash3);
+        }
+    }
+}

--- a/src/test/java/com/example/chalpuplatform/coupon/domain/CouponMembershipTest.java
+++ b/src/test/java/com/example/chalpuplatform/coupon/domain/CouponMembershipTest.java
@@ -1,0 +1,165 @@
+package com.example.chalpuplatform.coupon.domain;
+
+import com.example.chalpuplatform.common.exception.CouponException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CouponMembership 도메인 테스트")
+class CouponMembershipTest {
+
+    private CouponMembership membership;
+
+    @BeforeEach
+    void setUp() {
+        membership = CouponMembership.create(1L, "hashedPhone123");
+    }
+
+    @Nested
+    @DisplayName("멤버십 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("멤버십을 생성한다")
+        void create_Success() {
+            CouponMembership newMembership = CouponMembership.create(1L, "hashedPhone");
+
+            assertThat(newMembership.getStoreId()).isEqualTo(1L);
+            assertThat(newMembership.getPhoneHash()).isEqualTo("hashedPhone");
+            assertThat(newMembership.getCurrentStamps()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("스탬프 추가 테스트")
+    class AddStampsTest {
+
+        @Test
+        @DisplayName("스탬프를 추가한다")
+        void addStamps_Success() {
+            membership.addStamps(5);
+
+            assertThat(membership.getCurrentStamps()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("스탬프를 누적해서 추가한다")
+        void addStamps_Accumulate() {
+            membership.addStamps(3);
+            membership.addStamps(2);
+            membership.addStamps(5);
+
+            assertThat(membership.getCurrentStamps()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("0 이하의 스탬프는 추가할 수 없다")
+        void addStamps_Zero_ThrowsException() {
+            assertThatThrownBy(() -> membership.addStamps(0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("0보다 커야");
+        }
+
+        @Test
+        @DisplayName("음수 스탬프는 추가할 수 없다")
+        void addStamps_Negative_ThrowsException() {
+            assertThatThrownBy(() -> membership.addStamps(-1))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("null 스탬프는 추가할 수 없다")
+        void addStamps_Null_ThrowsException() {
+            assertThatThrownBy(() -> membership.addStamps(null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 사용 가능 여부 테스트")
+    class CanRedeemTest {
+
+        @Test
+        @DisplayName("스탬프가 부족하면 사용할 수 없다")
+        void canRedeem_InsufficientStamps_ReturnsFalse() {
+            membership.addStamps(9);
+
+            assertThat(membership.canRedeem(10)).isFalse();
+        }
+
+        @Test
+        @DisplayName("스탬프가 충분하면 사용할 수 있다")
+        void canRedeem_SufficientStamps_ReturnsTrue() {
+            membership.addStamps(10);
+
+            assertThat(membership.canRedeem(10)).isTrue();
+        }
+
+        @Test
+        @DisplayName("스탬프가 필요량보다 많아도 사용할 수 있다")
+        void canRedeem_MoreThanRequired_ReturnsTrue() {
+            membership.addStamps(15);
+
+            assertThat(membership.canRedeem(10)).isTrue();
+        }
+
+        @Test
+        @DisplayName("매장별 설정값에 따라 사용 가능 여부가 결정된다")
+        void canRedeem_DifferentRequiredStamps() {
+            membership.addStamps(12);
+
+            assertThat(membership.canRedeem(10)).isTrue();
+            assertThat(membership.canRedeem(15)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 사용 테스트")
+    class RedeemTest {
+
+        @Test
+        @DisplayName("쿠폰을 사용하면 스탬프가 차감된다")
+        void redeem_Success() {
+            membership.addStamps(15);
+
+            membership.redeem(10);
+
+            assertThat(membership.getCurrentStamps()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("스탬프가 부족하면 쿠폰을 사용할 수 없다")
+        void redeem_InsufficientStamps_ThrowsException() {
+            membership.addStamps(9);
+
+            assertThatThrownBy(() -> membership.redeem(10))
+                    .isInstanceOf(CouponException.class);
+        }
+
+        @Test
+        @DisplayName("쿠폰을 여러 번 사용할 수 있다")
+        void redeem_Multiple() {
+            membership.addStamps(25);
+
+            membership.redeem(10);
+            assertThat(membership.getCurrentStamps()).isEqualTo(15);
+
+            membership.redeem(10);
+            assertThat(membership.getCurrentStamps()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("매장별 설정값에 따라 차감된다")
+        void redeem_DifferentRequiredStamps() {
+            membership.addStamps(20);
+
+            membership.redeem(15);
+
+            assertThat(membership.getCurrentStamps()).isEqualTo(5);
+        }
+    }
+}

--- a/src/test/java/com/example/chalpuplatform/coupon/domain/CouponPinHistoryTest.java
+++ b/src/test/java/com/example/chalpuplatform/coupon/domain/CouponPinHistoryTest.java
@@ -1,0 +1,100 @@
+package com.example.chalpuplatform.coupon.domain;
+
+import com.example.chalpuplatform.common.exception.CouponException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CouponPinHistory 도메인 테스트")
+class CouponPinHistoryTest {
+
+    private CouponPinHistory pinHistory;
+
+    @BeforeEach
+    void setUp() {
+        pinHistory = CouponPinHistory.create(1L, "47", 2);
+    }
+
+    @Nested
+    @DisplayName("PIN 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("PIN을 생성한다")
+        void create_Success() {
+            CouponPinHistory newPin = CouponPinHistory.create(1L, "99", 5);
+
+            assertThat(newPin.getStoreId()).isEqualTo(1L);
+            assertThat(newPin.getPin()).isEqualTo("99");
+            assertThat(newPin.getStamps()).isEqualTo(5);
+            assertThat(newPin.getIsUsed()).isFalse();
+            assertThat(newPin.getPhoneHash()).isNull();
+        }
+
+        @Test
+        @DisplayName("PIN 만료 시간은 생성 시점으로부터 3분 후다")
+        void create_ExpirationTime() {
+            LocalDateTime before = LocalDateTime.now().plusMinutes(3).minusSeconds(1);
+            CouponPinHistory newPin = CouponPinHistory.create(1L, "47", 2);
+            LocalDateTime after = LocalDateTime.now().plusMinutes(3).plusSeconds(1);
+
+            assertThat(newPin.getExpiredAt()).isBetween(before, after);
+        }
+    }
+
+    @Nested
+    @DisplayName("PIN 유효성 검증 테스트")
+    class ValidationTest {
+
+        @Test
+        @DisplayName("생성 직후 PIN은 유효하다")
+        void isValid_JustCreated_ReturnsTrue() {
+            assertThat(pinHistory.isValid()).isTrue();
+        }
+
+        @Test
+        @DisplayName("생성 직후 PIN은 만료되지 않았다")
+        void isExpired_JustCreated_ReturnsFalse() {
+            assertThat(pinHistory.isExpired()).isFalse();
+        }
+
+        @Test
+        @DisplayName("사용된 PIN은 유효하지 않다")
+        void isValid_Used_ReturnsFalse() {
+            pinHistory.markAsUsed("hashedPhone");
+
+            assertThat(pinHistory.isValid()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("PIN 사용 처리 테스트")
+    class MarkAsUsedTest {
+
+        @Test
+        @DisplayName("PIN을 사용 처리한다")
+        void markAsUsed_Success() {
+            String phoneHash = "hashedPhone123";
+
+            pinHistory.markAsUsed(phoneHash);
+
+            assertThat(pinHistory.getIsUsed()).isTrue();
+            assertThat(pinHistory.getPhoneHash()).isEqualTo(phoneHash);
+        }
+
+        @Test
+        @DisplayName("이미 사용된 PIN은 다시 사용할 수 없다")
+        void markAsUsed_AlreadyUsed_ThrowsException() {
+            pinHistory.markAsUsed("hashedPhone1");
+
+            assertThatThrownBy(() -> pinHistory.markAsUsed("hashedPhone2"))
+                    .isInstanceOf(CouponException.class);
+        }
+    }
+}

--- a/src/test/java/com/example/chalpuplatform/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/example/chalpuplatform/coupon/service/CouponServiceTest.java
@@ -1,0 +1,266 @@
+package com.example.chalpuplatform.coupon.service;
+
+import com.example.chalpuplatform.common.exception.CouponException;
+import com.example.chalpuplatform.common.exception.StoreException;
+import com.example.chalpuplatform.coupon.domain.CouponMembership;
+import com.example.chalpuplatform.coupon.domain.CouponPinHistory;
+import com.example.chalpuplatform.coupon.dto.*;
+import com.example.chalpuplatform.coupon.repository.CouponMembershipRepository;
+import com.example.chalpuplatform.coupon.repository.CouponPinHistoryRepository;
+import com.example.chalpuplatform.store.domain.Store;
+import com.example.chalpuplatform.store.domain.UserStoreRole;
+import com.example.chalpuplatform.store.repository.StoreRepository;
+import com.example.chalpuplatform.store.repository.UserStoreRoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CouponService 테스트")
+class CouponServiceTest {
+
+    @Mock
+    private CouponMembershipRepository membershipRepository;
+
+    @Mock
+    private CouponPinHistoryRepository pinHistoryRepository;
+
+    @Mock
+    private UserStoreRoleRepository userStoreRoleRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private CouponService couponService;
+
+    private Store store;
+    private CouponMembership membership;
+    private CouponPinHistory pinHistory;
+
+    @BeforeEach
+    void setUp() {
+        store = Store.builder()
+                .id(1L)
+                .storeName("테스트 매장")
+                .requiredStampsForCoupon(10)
+                .build();
+
+        membership = CouponMembership.builder()
+                .id(1L)
+                .storeId(1L)
+                .phoneHash("hashedPhone")
+                .currentStamps(5)
+                .build();
+
+        pinHistory = CouponPinHistory.builder()
+                .id(1L)
+                .storeId(1L)
+                .pin("47")
+                .stamps(2)
+                .isUsed(false)
+                .expiredAt(LocalDateTime.now().plusMinutes(3))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("멤버십 조회 테스트")
+    class GetMembershipTest {
+
+        @Test
+        @DisplayName("존재하는 멤버십을 조회한다")
+        void getMembership_Exists_ReturnsResponse() {
+            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+            given(membershipRepository.findByStoreIdAndPhoneHash(anyLong(), anyString()))
+                    .willReturn(Optional.of(membership));
+
+            CouponMembershipResponse response = couponService.getMembership(1L, "010-1234-5678");
+
+            assertThat(response.getCurrentStamps()).isEqualTo(5);
+            assertThat(response.getRequiredStamps()).isEqualTo(10);
+            assertThat(response.getCanRedeem()).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 멤버십은 빈 응답을 반환한다")
+        void getMembership_NotExists_ReturnsEmpty() {
+            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+            given(membershipRepository.findByStoreIdAndPhoneHash(anyLong(), anyString()))
+                    .willReturn(Optional.empty());
+
+            CouponMembershipResponse response = couponService.getMembership(1L, "010-1234-5678");
+
+            assertThat(response.getCurrentStamps()).isZero();
+            assertThat(response.getRequiredStamps()).isEqualTo(10);
+            assertThat(response.getCanRedeem()).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 매장은 예외를 발생시킨다")
+        void getMembership_StoreNotFound_ThrowsException() {
+            given(storeRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> couponService.getMembership(1L, "010-1234-5678"))
+                    .isInstanceOf(StoreException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("스탬프 적립 테스트")
+    class EarnStampsTest {
+
+        @Test
+        @DisplayName("유효한 PIN으로 스탬프를 적립한다")
+        void earnStamps_ValidPin_Success() {
+            CouponEarnRequest request = new CouponEarnRequest(1L, "010-1234-5678", "47");
+
+            given(pinHistoryRepository.findByStoreIdAndPinAndIsUsedFalse(1L, "47"))
+                    .willReturn(Optional.of(pinHistory));
+            given(membershipRepository.findByStoreIdAndPhoneHash(anyLong(), anyString()))
+                    .willReturn(Optional.of(membership));
+            given(membershipRepository.save(any())).willReturn(membership);
+            given(pinHistoryRepository.save(any())).willReturn(pinHistory);
+
+            CouponEarnResponse response = couponService.earnStamps(request);
+
+            assertThat(response.getSuccess()).isTrue();
+            assertThat(response.getCurrentStamps()).isEqualTo(7);
+            verify(pinHistoryRepository).save(any());
+            verify(membershipRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("멤버십이 없으면 새로 생성한다")
+        void earnStamps_NewMembership_CreatesNew() {
+            CouponEarnRequest request = new CouponEarnRequest(1L, "010-1234-5678", "47");
+
+            given(pinHistoryRepository.findByStoreIdAndPinAndIsUsedFalse(1L, "47"))
+                    .willReturn(Optional.of(pinHistory));
+            given(membershipRepository.findByStoreIdAndPhoneHash(anyLong(), anyString()))
+                    .willReturn(Optional.empty());
+            given(membershipRepository.save(any())).willReturn(membership);
+            given(pinHistoryRepository.save(any())).willReturn(pinHistory);
+
+            CouponEarnResponse response = couponService.earnStamps(request);
+
+            assertThat(response.getSuccess()).isTrue();
+            verify(membershipRepository, times(2)).save(any());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 PIN은 예외를 발생시킨다")
+        void earnStamps_InvalidPin_ThrowsException() {
+            CouponEarnRequest request = new CouponEarnRequest(1L, "010-1234-5678", "99");
+
+            given(pinHistoryRepository.findByStoreIdAndPinAndIsUsedFalse(1L, "99"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> couponService.earnStamps(request))
+                    .isInstanceOf(CouponException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 사용 테스트")
+    class RedeemCouponTest {
+
+        @Test
+        @DisplayName("쿠폰을 사용한다")
+        void redeemCoupon_Success() {
+            CouponRedeemRequest request = new CouponRedeemRequest(1L, "010-1234-5678");
+            CouponMembership membershipWith10Stamps = CouponMembership.builder()
+                    .id(1L)
+                    .storeId(1L)
+                    .phoneHash("hashedPhone")
+                    .currentStamps(10)
+                    .build();
+
+            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+            given(membershipRepository.findByStoreIdAndPhoneHash(anyLong(), anyString()))
+                    .willReturn(Optional.of(membershipWith10Stamps));
+            given(membershipRepository.save(any())).willReturn(membershipWith10Stamps);
+
+            CouponRedeemResponse response = couponService.redeemCoupon(request);
+
+            assertThat(response.getSuccess()).isTrue();
+            assertThat(response.getCurrentStamps()).isZero();
+            verify(membershipRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("멤버십이 없으면 예외를 발생시킨다")
+        void redeemCoupon_NoMembership_ThrowsException() {
+            CouponRedeemRequest request = new CouponRedeemRequest(1L, "010-1234-5678");
+
+            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+            given(membershipRepository.findByStoreIdAndPhoneHash(anyLong(), anyString()))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> couponService.redeemCoupon(request))
+                    .isInstanceOf(CouponException.class);
+        }
+
+        @Test
+        @DisplayName("스탬프가 부족하면 예외를 발생시킨다")
+        void redeemCoupon_InsufficientStamps_ThrowsException() {
+            CouponRedeemRequest request = new CouponRedeemRequest(1L, "010-1234-5678");
+
+            given(storeRepository.findById(1L)).willReturn(Optional.of(store));
+            given(membershipRepository.findByStoreIdAndPhoneHash(anyLong(), anyString()))
+                    .willReturn(Optional.of(membership));
+
+            assertThatThrownBy(() -> couponService.redeemCoupon(request))
+                    .isInstanceOf(CouponException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("PIN 발급 테스트")
+    class IssuePinTest {
+
+        @Test
+        @DisplayName("권한이 있으면 PIN을 발급한다")
+        void issuePin_WithPermission_Success() {
+            CouponIssuePinRequest request = new CouponIssuePinRequest(1L, 2);
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(1L, 1L))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(pinHistoryRepository.save(any())).willReturn(pinHistory);
+
+            CouponIssuePinResponse response = couponService.issuePin(1L, request);
+
+            assertThat(response.getPin()).hasSize(2);
+            assertThat(response.getStamps()).isEqualTo(2);
+            assertThat(response.getExpiredAt()).isNotNull();
+            verify(pinHistoryRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("권한이 없으면 예외를 발생시킨다")
+        void issuePin_NoPermission_ThrowsException() {
+            CouponIssuePinRequest request = new CouponIssuePinRequest(1L, 2);
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(1L, 1L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> couponService.issuePin(1L, request))
+                    .isInstanceOf(StoreException.class);
+        }
+    }
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -50,6 +50,7 @@ module "parameter_store" {
   kakao_client_secret       = var.kakao_client_secret
   google_client_id          = var.google_client_id
   google_client_secret      = var.google_client_secret
+  google_mobile_client_ids  = var.google_mobile_client_ids
   oauth2_redirect_success_path = var.oauth2_redirect_success_path
   oauth2_redirect_failure_path = var.oauth2_redirect_failure_path
   oauth2_owner_domain       = var.oauth2_owner_domain

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -120,6 +120,11 @@ variable "google_client_secret" {
   sensitive   = true
 }
 
+variable "google_mobile_client_ids" {
+  description = "Google mobile client IDs (Android, iOS) separated by comma"
+  type        = string
+}
+
 variable "oauth2_redirect_success_path" {
   description = "OAuth2 redirect success path"
   type        = string

--- a/terraform/modules/secret/parameter-store/main.tf
+++ b/terraform/modules/secret/parameter-store/main.tf
@@ -147,6 +147,18 @@ resource "aws_ssm_parameter" "google_client_secret" {
   }
 }
 
+resource "aws_ssm_parameter" "google_mobile_client_ids" {
+  name        = "/chalpu-platform/${var.environment}/google-mobile-client-ids"
+  description = "Google mobile client IDs (Android, iOS)"
+  type        = "String"
+  value       = var.google_mobile_client_ids
+
+  tags = {
+    Name        = "chalpu-${var.environment}-google-mobile-client-ids"
+    Environment = var.environment
+  }
+}
+
 # OAuth2 Redirect Configuration
 resource "aws_ssm_parameter" "oauth2_redirect_success_path" {
   name        = "/chalpu-platform/${var.environment}/oauth2-redirect-success-path"

--- a/terraform/modules/secret/parameter-store/variables.tf
+++ b/terraform/modules/secret/parameter-store/variables.tf
@@ -72,6 +72,11 @@ variable "google_client_secret" {
   sensitive   = true
 }
 
+variable "google_mobile_client_ids" {
+  description = "Google mobile client IDs (Android, iOS) separated by comma"
+  type        = string
+}
+
 variable "oauth2_redirect_success_path" {
   description = "OAuth2 redirect success path"
   type        = string


### PR DESCRIPTION
  ### 변경 내용
  - 쿠폰 스탬프 시스템을 구현했습니다
    - 고객이 전화번호로 스탬프를 적립하고 쿠폰으로 교환할 수 있는 멤버십 기능
    - 사장님이 PIN을 발급하여 고객에게 스탬프를 제공하는 시스템
    - 전화번호 해싱(SHA-256)을 통한 개인정보 보호
    - PIN 기반 스탬프 적립 (2자리, 3분 만료)

  - **Store 엔티티에 `requiredStampsForCoupon` 필드를 추가했습니다**
    - **매장별로 쿠폰 사용에 필요한 스탬프 개수를 설정할 수 있습니다 (기본값: 10개)**
    - **StoreRequest, StoreResponse DTO에도 해당 필드를 추가했습니다**
    
<img width="516" height="663" alt="image" src="https://github.com/user-attachments/assets/537865da-b343-4a33-bbae-14e877b3e0d0" />


  ### API 엔드포인트

  #### 고객용 (인증 불필요)

  - `GET /api/coupon/membership` - 멤버십 조회
    - Query Params: `storeId`, `phone`
    - Response: 현재 스탬프 개수, 필요 스탬프 개수, 사용 가능 여부

  - `POST /api/coupon/earn` - 스탬프 적립
    - Request Body: `storeId`, `phone`, `pin`
    - Response: 적립 후 스탬프 개수

  - `POST /api/coupon/redeem` - 쿠폰 사용
    - Request Body: `storeId`, `phone`
    - Response: 사용 후 스탬프 개수

  #### 사장님용 (JWT 인증 필요)
  - `POST /api/owner/coupon/issue-pin` - PIN 발급
    - Request Body: `storeId`, `stamps`
    - Response: 발급된 PIN(2자리), 만료 시간(3분)

  ### 데이터베이스 테이블

  #### coupon_membership
  - id (PK)
  - store_id
  - phone_hash (SHA-256 해시값)
  - current_stamps (현재 스탬프 개수)
  - created_at, updated_at

  #### coupon_pin_history

  - id (PK)
  - store_id
  - pin (2자리 숫자)
  - stamps (적립 스탬프 개수)
  - is_used (사용 여부)
  - phone_hash (사용한 고객, nullable)
  - expired_at (만료 시간, 발급 후 3분)
  - created_at, updated_at

  클라이언트 구현 가이드

  ### 1. 멤버십 조회 

```
  // GET /api/coupon/membership?storeId=1&phone=010-1234-5678
  {
    "currentStamps": 5,
    "requiredStamps": 10,  // 매장별로 다를 수 있음
    "canRedeem": false
  }
-> phone=010-1234-5678 or 010:1234:5678 or 01012345678 다 됨.
```

  ### 2. 스탬프 적립 플로우

  1. 사장님이 "PIN 발급" 버튼 클릭 → 적립할 스탬프 개수 입력 (예: 2개)
  2. 서버에서 2자리 PIN 발급 (예: "47")
  3. 사장님이 고객에게 PIN을 보여줌 (3분 내 입력 필요)
  4. 고객이 앱에서 전화번호 + PIN 입력
  5. 스탬프 적립 완료

```
  // POST /api/coupon/earn
  {
    "storeId": 1,
    "phone": "010-1234-5678",
    "pin": "47"
  }

  // Response
  {
    "success": true,
    "currentStamps": 7,
    "addedStamps": 2
  }
```

  ### 3. 쿠폰 사용

```
  // POST /api/coupon/redeem
  {
    "storeId": 1,
    "phone": "010-1234-5678"
  }

  // Response
  {
    "success": true,
    "currentStamps": 0,  // 스탬프 차감됨
    "redeemedStamps": 10
  }
```

  ### 4. PIN 발급 (사장님용, Authorization 헤더 필요)
```
  // POST /api/owner/coupon/issue-pin
  // Headers: { "Authorization": "Bearer {JWT}" }
  {
    "storeId": 1,
    "stamps": 2
  }

  // Response
  {
    "pin": "47",
    "stamps": 2,
    "expiredAt": "2025-10-20T15:23:00"
  }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced coupon system enabling customers to earn stamps by validating store-issued PINs
  * Store owners can issue PINs to encourage customer participation
  * Customers can redeem coupons upon reaching configurable stamp thresholds
  * Stamp tracking and membership management by phone number

* **Tests**
  * Added comprehensive test coverage for coupon domain and service operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->