### PR TITLE
feat (storeNotice): 가게의 공지 엔티티 추가

### DIFF
--- a/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
@@ -66,6 +66,8 @@ public enum ErrorMessage {
     STORE_NAME_ALREADY_EXISTS(BAD_REQUEST, "이미 존재하는 매장 이름입니다."),
     SITE_LINK_ALREADY_EXISTS(BAD_REQUEST, "이미 사용 중인 사이트 링크입니다."),
     SITE_CANNOT_NULL(BAD_REQUEST, "사이트 링크는 null일 수 없습니다."),
+    STORE_NOTICE_NOT_FOUND(NOT_FOUND, "가게 공지사항을 찾을 수 없습니다."),
+    STORE_NOTICE_ACCESS_DENIED(FORBIDDEN, "가게 공지사항 접근 권한이 없습니다."),
 
     // 메뉴 관련 에러
     MENU_NOT_FOUND(NOT_FOUND, "메뉴를 찾을 수 없습니다."),

--- a/src/main/java/com/example/chalpuplatform/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/chalpuplatform/oauth/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/campaigns/types").permitAll()
                         .requestMatchers("/api/campaigns/sns-platforms").permitAll()
                         .requestMatchers("/api/campaigns/campaign-platforms").permitAll()
+                        .requestMatchers("/api/stores/{storeId}/notices").permitAll()
                         // 공지사항/홈 광고 배너 관련 경로
                         .requestMatchers("/api/notices/**").permitAll()
                         // 앱 버전 관련 경로

--- a/src/main/java/com/example/chalpuplatform/store/controller/StoreNoticeController.java
+++ b/src/main/java/com/example/chalpuplatform/store/controller/StoreNoticeController.java
@@ -1,0 +1,115 @@
+package com.example.chalpuplatform.store.controller;
+
+import com.example.chalpuplatform.common.response.ApiResponse;
+import com.example.chalpuplatform.common.response.PageResponse;
+import com.example.chalpuplatform.oauth.jwt.UserDetailsImpl;
+import com.example.chalpuplatform.store.dto.CreateStoreNoticeRequest;
+import com.example.chalpuplatform.store.dto.StoreNoticeDeleteDto;
+import com.example.chalpuplatform.store.dto.StoreNoticeResponse;
+import com.example.chalpuplatform.store.dto.UpdateStoreNoticeRequest;
+import com.example.chalpuplatform.store.service.StoreNoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stores")
+@Tag(name = "Store Notice", description = "가게 공지사항 API")
+public class StoreNoticeController {
+
+    private final StoreNoticeService storeNoticeService;
+
+    /**
+     * 가게 공지사항을 생성합니다.
+     *
+     * @param storeId 가게 ID
+     * @param request 공지사항 생성 요청 데이터
+     * @return 생성된 공지사항 정보
+     */
+    @PostMapping("/{storeId}/notices")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "가게 공지사항 생성", description = "새로운 가게 공지사항을 생성합니다. 매장 관리 권한이 필요합니다.")
+    public ResponseEntity<ApiResponse<StoreNoticeResponse>> createNotice(
+            @PathVariable("storeId") Long storeId,
+            @RequestBody @Valid CreateStoreNoticeRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        StoreNoticeResponse response = storeNoticeService.createNotice(storeId, request,userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 특정 가게의 공지사항 목록을 조회합니다.
+     *
+     * @param storeId 가게 ID
+     * @param pageable 페이징 정보
+     * @return 공지사항 페이지 응답
+     */
+    @GetMapping("/{storeId}/notices")
+    @Operation(
+            summary = "가게 공지사항 목록 조회",
+            description = """
+                    특정 가게의 공지사항 목록을 페이지네이션으로 조회합니다.
+
+                    **페이지네이션 파라미터:**
+                    - page: 페이지 번호 (0부터 시작, 기본값: 0)
+                    - size: 페이지 크기 (기본값: 20)
+                    - sort: 정렬 조건 (기본값: createdAt,desc)
+                    """
+    )
+    public ResponseEntity<ApiResponse<PageResponse<StoreNoticeResponse>>> getNotices(
+            @PathVariable("storeId") Long storeId,
+            @Parameter(description = "페이지네이션 정보")
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        PageResponse<StoreNoticeResponse> notices = storeNoticeService.getNotices(storeId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(notices));
+    }
+
+    /**
+     * 공지사항을 수정합니다.
+     *
+     * @param noticeId 공지사항 ID
+     * @param request 공지사항 수정 요청 데이터
+     * @return 수정된 공지사항 정보
+     */
+    @PutMapping("/notices/{noticeId}")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "가게 공지사항 수정", description = "가게 공지사항 내용을 수정합니다. 매장 관리 권한이 필요합니다.")
+    public ResponseEntity<ApiResponse<StoreNoticeResponse>> updateNotice(
+            @PathVariable("noticeId") Long noticeId,
+            @RequestBody @Valid UpdateStoreNoticeRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        StoreNoticeResponse response = storeNoticeService.updateNotice(noticeId, request, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 공지사항을 삭제합니다.
+     *
+     * @param storeNoticeDeleteDto 공지사항 ID
+     * @return 삭제 성공 응답
+     */
+    @DeleteMapping("/{storeId}/notices")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "가게 공지사항 삭제", description = "가게 공지사항을 삭제합니다. 매장 관리 권한이 필요합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteNotice(
+            @PathVariable(name = "storeId") Long storeId,
+            @RequestBody StoreNoticeDeleteDto storeNoticeDeleteDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        storeNoticeService.deleteNotice(storeNoticeDeleteDto, storeId,userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/store/domain/StoreNotice.java
+++ b/src/main/java/com/example/chalpuplatform/store/domain/StoreNotice.java
@@ -1,0 +1,41 @@
+package com.example.chalpuplatform.store.domain;
+
+import com.example.chalpuplatform.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "store_notices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreNotice extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "store_id", nullable = false)
+    private Long storeId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @Builder
+    public StoreNotice(Long storeId, String title, String body) {
+        this.storeId = storeId;
+        this.title = title;
+        this.body = body;
+    }
+
+    public void update(String title, String body) {
+        this.title = title;
+        this.body = body;
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/store/dto/CreateStoreNoticeRequest.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/CreateStoreNoticeRequest.java
@@ -1,0 +1,22 @@
+package com.example.chalpuplatform.store.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "가게 공지사항 생성 요청")
+public class CreateStoreNoticeRequest {
+
+    @NotBlank
+    @Schema(description = "공지사항 제목", example = "설 연휴 휴무 안내")
+    private String title;
+
+    @NotBlank
+    @Schema(description = "공지사항 내용", example = "2024년 2월 9일부터 2월 12일까지 휴무입니다.")
+    private String body;
+}

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreNoticeDeleteDto.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreNoticeDeleteDto.java
@@ -1,0 +1,20 @@
+package com.example.chalpuplatform.store.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "공지사항 벌크 삭제 요청")
+public class StoreNoticeDeleteDto {
+
+    @NotEmpty
+    @Schema(description = "삭제할 공지사항 ID 목록", example = "[1, 2, 3]")
+    private List<Long> deleteIds;
+}

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreNoticeResponse.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreNoticeResponse.java
@@ -1,0 +1,47 @@
+package com.example.chalpuplatform.store.dto;
+
+import com.example.chalpuplatform.store.domain.StoreNotice;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "가게 공지사항 응답")
+public class StoreNoticeResponse {
+
+    @Schema(description = "공지사항 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "가게 ID", example = "1")
+    private Long storeId;
+
+    @Schema(description = "공지사항 제목", example = "설 연휴 휴무 안내")
+    private String title;
+
+    @Schema(description = "공지사항 내용", example = "2024년 2월 9일부터 2월 12일까지 휴무입니다.")
+    private String body;
+
+    @Schema(description = "생성 시간")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시간")
+    private LocalDateTime updatedAt;
+
+    public static StoreNoticeResponse from(StoreNotice storeNotice) {
+        return StoreNoticeResponse.builder()
+                .id(storeNotice.getId())
+                .storeId(storeNotice.getStoreId())
+                .title(storeNotice.getTitle())
+                .body(storeNotice.getBody())
+                .createdAt(storeNotice.getCreatedAt())
+                .updatedAt(storeNotice.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/chalpuplatform/store/dto/UpdateStoreNoticeRequest.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/UpdateStoreNoticeRequest.java
@@ -1,0 +1,22 @@
+package com.example.chalpuplatform.store.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "가게 공지사항 수정 요청")
+public class UpdateStoreNoticeRequest {
+
+    @NotBlank
+    @Schema(description = "공지사항 제목", example = "설 연휴 휴무 안내")
+    private String title;
+
+    @NotBlank
+    @Schema(description = "공지사항 내용", example = "2024년 2월 9일부터 2월 12일까지 휴무입니다.")
+    private String body;
+}

--- a/src/main/java/com/example/chalpuplatform/store/repository/StoreNoticeRepository.java
+++ b/src/main/java/com/example/chalpuplatform/store/repository/StoreNoticeRepository.java
@@ -1,0 +1,13 @@
+package com.example.chalpuplatform.store.repository;
+
+import com.example.chalpuplatform.store.domain.StoreNotice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreNoticeRepository extends JpaRepository<StoreNotice, Long> {
+
+    Page<StoreNotice> findByStoreId(Long storeId, Pageable pageable);
+}

--- a/src/main/java/com/example/chalpuplatform/store/service/StoreNoticeService.java
+++ b/src/main/java/com/example/chalpuplatform/store/service/StoreNoticeService.java
@@ -1,0 +1,146 @@
+package com.example.chalpuplatform.store.service;
+
+import com.example.chalpuplatform.common.exception.ErrorMessage;
+import com.example.chalpuplatform.common.exception.StoreException;
+import com.example.chalpuplatform.common.response.PageResponse;
+import com.example.chalpuplatform.store.domain.StoreNotice;
+import com.example.chalpuplatform.store.dto.CreateStoreNoticeRequest;
+import com.example.chalpuplatform.store.dto.StoreNoticeDeleteDto;
+import com.example.chalpuplatform.store.dto.StoreNoticeResponse;
+import com.example.chalpuplatform.store.dto.UpdateStoreNoticeRequest;
+import com.example.chalpuplatform.store.repository.StoreNoticeRepository;
+import com.example.chalpuplatform.store.repository.UserStoreRoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StoreNoticeService {
+
+    private final StoreNoticeRepository storeNoticeRepository;
+    private final UserStoreRoleRepository userStoreRoleRepository;
+
+    /**
+     * 가게 공지사항을 생성합니다.
+     *
+     * @param storeId 가게 ID
+     * @param request 공지사항 생성 요청 데이터
+     * @return 생성된 공지사항 정보
+     * @throws StoreException 가게를 찾을 수 없는 경우
+     */
+    public StoreNoticeResponse createNotice(Long storeId, CreateStoreNoticeRequest request,Long userId) {
+        try {
+            userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+
+            StoreNotice notice = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title(request.getTitle())
+                    .body(request.getBody())
+                    .build();
+
+            StoreNotice savedNotice = storeNoticeRepository.save(notice);
+
+            log.info("event=store_notice_created, store_id={}, notice_id={}", storeId, savedNotice.getId());
+            return StoreNoticeResponse.from(savedNotice);
+        } catch (StoreException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("event=store_notice_creation_failed, store_id={}, error_message={}", storeId, e.getMessage(), e);
+            throw new StoreException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 특정 가게의 공지사항 목록을 조회합니다.
+     *
+     * @param storeId 가게 ID
+     * @param pageable 페이징 정보
+     * @return 공지사항 페이지 응답
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<StoreNoticeResponse> getNotices(Long storeId, Pageable pageable) {
+        try {
+            Page<StoreNotice> noticePage = storeNoticeRepository.findByStoreId(storeId, pageable);
+            Page<StoreNoticeResponse> responsePage = noticePage.map(StoreNoticeResponse::from);
+
+            log.info("event=store_notices_retrieved, store_id={}, total_count={}", storeId, noticePage.getTotalElements());
+            return PageResponse.from(responsePage);
+        } catch (Exception e) {
+            log.error("event=store_notices_retrieval_failed, store_id={}, error_message={}", storeId, e.getMessage(), e);
+            throw new StoreException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 공지사항을 수정합니다.
+     *
+     * @param noticeId 공지사항 ID
+     * @param request 공지사항 수정 요청 데이터
+     * @param userId 사용자 ID
+     * @return 수정된 공지사항 정보
+     * @throws StoreException 공지사항을 찾을 수 없는 경우
+     */
+    public StoreNoticeResponse updateNotice(Long noticeId, UpdateStoreNoticeRequest request, Long userId) {
+        try {
+            StoreNotice notice = storeNoticeRepository.findById(noticeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOTICE_NOT_FOUND));
+
+            userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, notice.getStoreId())
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+
+            notice.update(request.getTitle(), request.getBody());
+
+            log.info("event=store_notice_updated, notice_id={}, store_id={}", noticeId, notice.getStoreId());
+            return StoreNoticeResponse.from(notice);
+        } catch (StoreException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("event=store_notice_update_failed, notice_id={}, error_message={}", noticeId, e.getMessage(), e);
+            throw new StoreException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 공지사항을 벌크 삭제합니다.
+     *
+     * @param dto 삭제할 공지사항 ID 목록
+     * @param userId 사용자 ID
+     * @throws StoreException 공지사항을 찾을 수 없는 경우
+     */
+    public void deleteNotice(StoreNoticeDeleteDto dto, Long storeId,Long userId) {
+        try {
+            userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+
+            List<Long> noticeIds = dto.getDeleteIds();
+
+            if (noticeIds == null || noticeIds.isEmpty()) {
+                throw new StoreException(ErrorMessage.INVALID_PARAMETER);
+            }
+
+            List<StoreNotice> notices = storeNoticeRepository.findAllById(noticeIds);
+
+            if (notices.size() != noticeIds.size()) {
+                throw new StoreException(ErrorMessage.STORE_NOTICE_NOT_FOUND);
+            }
+
+            storeNoticeRepository.deleteAllById(noticeIds);
+
+            log.info("event=store_notices_bulk_deleted, count={}, notice_ids={}", noticeIds.size(), noticeIds);
+        } catch (StoreException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("event=store_notices_bulk_deletion_failed, error_message={}", e.getMessage(), e);
+            throw new StoreException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/test/java/com/example/chalpuplatform/store/StoreServiceTransactionTest.java
+++ b/src/test/java/com/example/chalpuplatform/store/StoreServiceTransactionTest.java
@@ -113,6 +113,7 @@ class StoreServiceTransactionTest {
                 LinkType.BAEMIN,
                 null,
                 "https://baemin.com/test",
+                true,
                 0
         );
 
@@ -155,8 +156,8 @@ class StoreServiceTransactionTest {
         System.out.println("    Store siteLink: " + savedStore.getSiteLink());
 
         System.out.println("\n>>> 3. StoreLink 생성");
-        StoreLink link1 = StoreLink.create(savedStore, LinkType.BAEMIN, null, "https://baemin.com", 0);
-        StoreLink link2 = StoreLink.create(savedStore, LinkType.YOGIYO, null, "https://yogiyo.com", 1);
+        StoreLink link1 = StoreLink.create(savedStore, LinkType.BAEMIN, null, "https://baemin.com", true, 0);
+        StoreLink link2 = StoreLink.create(savedStore, LinkType.YOGIYO, null, "https://yogiyo.com", true, 1);
 
         System.out.println("\n>>> 4. storeLinkRepository.save() 호출 - IDENTITY이므로 즉시 INSERT");
         StoreLink savedLink1 = storeLinkRepository.save(link1);

--- a/src/test/java/com/example/chalpuplatform/store/service/StoreNoticeServiceTest.java
+++ b/src/test/java/com/example/chalpuplatform/store/service/StoreNoticeServiceTest.java
@@ -1,0 +1,353 @@
+package com.example.chalpuplatform.store.service;
+
+import com.example.chalpuplatform.common.exception.ErrorMessage;
+import com.example.chalpuplatform.common.exception.StoreException;
+import com.example.chalpuplatform.common.response.PageResponse;
+import com.example.chalpuplatform.store.domain.StoreNotice;
+import com.example.chalpuplatform.store.domain.UserStoreRole;
+import com.example.chalpuplatform.store.dto.CreateStoreNoticeRequest;
+import com.example.chalpuplatform.store.dto.StoreNoticeDeleteDto;
+import com.example.chalpuplatform.store.dto.StoreNoticeResponse;
+import com.example.chalpuplatform.store.dto.UpdateStoreNoticeRequest;
+import com.example.chalpuplatform.store.repository.StoreNoticeRepository;
+import com.example.chalpuplatform.store.repository.UserStoreRoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StoreNoticeService 테스트")
+class StoreNoticeServiceTest {
+
+    @Mock
+    private StoreNoticeRepository storeNoticeRepository;
+
+    @Mock
+    private UserStoreRoleRepository userStoreRoleRepository;
+
+    @InjectMocks
+    private StoreNoticeService storeNoticeService;
+
+    private StoreNotice notice;
+    private CreateStoreNoticeRequest createRequest;
+    private UpdateStoreNoticeRequest updateRequest;
+    private Pageable pageable;
+    private Long userId = 1L;
+    private Long storeId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        notice = StoreNotice.builder()
+                .storeId(storeId)
+                .title("설 연휴 휴무 안내")
+                .body("2024년 2월 9일부터 2월 12일까지 휴무입니다.")
+                .build();
+
+        createRequest = new CreateStoreNoticeRequest(
+                "설 연휴 휴무 안내",
+                "2024년 2월 9일부터 2월 12일까지 휴무입니다."
+        );
+
+        updateRequest = new UpdateStoreNoticeRequest(
+                "추석 연휴 휴무 안내",
+                "2024년 9월 16일부터 9월 18일까지 휴무입니다."
+        );
+
+        pageable = PageRequest.of(0, 20);
+    }
+
+    @Nested
+    @DisplayName("공지사항 생성 테스트")
+    class CreateNoticeTest {
+
+        @Test
+        @DisplayName("공지사항을 성공적으로 생성한다")
+        void createNotice_Success() {
+            // given
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.save(any(StoreNotice.class)))
+                    .willReturn(notice);
+
+            // when
+            StoreNoticeResponse response = storeNoticeService.createNotice(storeId, createRequest, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getStoreId()).isEqualTo(1L);
+            assertThat(response.getTitle()).isEqualTo("설 연휴 휴무 안내");
+            assertThat(response.getBody()).isEqualTo("2024년 2월 9일부터 2월 12일까지 휴무입니다.");
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository).save(any(StoreNotice.class));
+        }
+
+        @Test
+        @DisplayName("사용자가 가게 권한이 없으면 예외가 발생한다")
+        void createNotice_UserHasNoPermission_ThrowsException() {
+            // given
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, 999L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.createNotice(999L, createRequest, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOT_FOUND);
+
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, 999L);
+            verify(storeNoticeRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 조회 테스트")
+    class GetNoticesTest {
+
+        @Test
+        @DisplayName("공지사항 목록을 성공적으로 조회한다")
+        void getNotices_Success() {
+            // given
+            StoreNotice notice1 = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title("공지1")
+                    .body("내용1")
+                    .build();
+            StoreNotice notice2 = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title("공지2")
+                    .body("내용2")
+                    .build();
+
+            Page<StoreNotice> noticePage = new PageImpl<>(List.of(notice1, notice2), pageable, 2);
+
+            given(storeNoticeRepository.findByStoreId(storeId, pageable))
+                    .willReturn(noticePage);
+
+            // when
+            PageResponse<StoreNoticeResponse> response = storeNoticeService.getNotices(storeId, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).hasSize(2);
+            assertThat(response.getTotalElements()).isEqualTo(2);
+            verify(storeNoticeRepository).findByStoreId(storeId, pageable);
+        }
+
+        @Test
+        @DisplayName("공지사항이 없으면 빈 페이지를 반환한다")
+        void getNotices_EmptyResult_ReturnsEmptyPage() {
+            // given
+            Page<StoreNotice> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+            given(storeNoticeRepository.findByStoreId(storeId, pageable))
+                    .willReturn(emptyPage);
+
+            // when
+            PageResponse<StoreNoticeResponse> response = storeNoticeService.getNotices(storeId, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).isEmpty();
+            assertThat(response.getTotalElements()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 수정 테스트")
+    class UpdateNoticeTest {
+
+        @Test
+        @DisplayName("공지사항을 성공적으로 수정한다")
+        void updateNotice_Success() {
+            // given
+            given(storeNoticeRepository.findById(1L))
+                    .willReturn(Optional.of(notice));
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+
+            // when
+            StoreNoticeResponse response = storeNoticeService.updateNotice(1L, updateRequest, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTitle()).isEqualTo("추석 연휴 휴무 안내");
+            assertThat(response.getBody()).isEqualTo("2024년 9월 16일부터 9월 18일까지 휴무입니다.");
+            verify(storeNoticeRepository).findById(1L);
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+        }
+
+        @Test
+        @DisplayName("공지사항을 찾을 수 없으면 예외가 발생한다")
+        void updateNotice_NoticeNotFound_ThrowsException() {
+            // given
+            given(storeNoticeRepository.findById(999L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.updateNotice(999L, updateRequest, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOTICE_NOT_FOUND);
+
+            verify(storeNoticeRepository).findById(999L);
+        }
+
+        @Test
+        @DisplayName("사용자가 가게 권한이 없으면 예외가 발생한다")
+        void updateNotice_UserHasNoPermission_ThrowsException() {
+            // given
+            given(storeNoticeRepository.findById(1L))
+                    .willReturn(Optional.of(notice));
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.updateNotice(1L, updateRequest, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOT_FOUND);
+
+            verify(storeNoticeRepository).findById(1L);
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 벌크 삭제 테스트")
+    class DeleteNoticeTest {
+
+        @Test
+        @DisplayName("여러 공지사항을 성공적으로 삭제한다")
+        void deleteNotice_BulkDelete_Success() {
+            // given
+            StoreNotice notice1 = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title("공지1")
+                    .body("내용1")
+                    .build();
+            StoreNotice notice2 = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title("공지2")
+                    .body("내용2")
+                    .build();
+
+            List<Long> deleteIds = List.of(1L, 2L);
+            StoreNoticeDeleteDto deleteDto = new StoreNoticeDeleteDto(deleteIds);
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.findAllById(deleteIds))
+                    .willReturn(List.of(notice1, notice2));
+
+            // when
+            storeNoticeService.deleteNotice(deleteDto, storeId, userId);
+
+            // then
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository).findAllById(deleteIds);
+            verify(storeNoticeRepository).deleteAllById(deleteIds);
+        }
+
+        @Test
+        @DisplayName("일부 공지사항을 찾을 수 없으면 예외가 발생한다")
+        void deleteNotice_SomeNoticesNotFound_ThrowsException() {
+            // given
+            StoreNotice notice1 = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title("공지1")
+                    .body("내용1")
+                    .build();
+
+            List<Long> deleteIds = List.of(1L, 999L);
+            StoreNoticeDeleteDto deleteDto = new StoreNoticeDeleteDto(deleteIds);
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.findAllById(deleteIds))
+                    .willReturn(List.of(notice1));
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.deleteNotice(deleteDto, storeId, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOTICE_NOT_FOUND);
+
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository).findAllById(deleteIds);
+            verify(storeNoticeRepository, never()).deleteAllById(any());
+        }
+
+        @Test
+        @DisplayName("삭제할 ID 목록이 비어있으면 예외가 발생한다")
+        void deleteNotice_EmptyIdList_ThrowsException() {
+            // given
+            StoreNoticeDeleteDto deleteDto = new StoreNoticeDeleteDto(List.of());
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.deleteNotice(deleteDto, storeId, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.INVALID_PARAMETER);
+
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository, never()).findAllById(any());
+            verify(storeNoticeRepository, never()).deleteAllById(any());
+        }
+
+        @Test
+        @DisplayName("삭제할 ID 목록이 null이면 예외가 발생한다")
+        void deleteNotice_NullIdList_ThrowsException() {
+            // given
+            StoreNoticeDeleteDto deleteDto = new StoreNoticeDeleteDto(null);
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.deleteNotice(deleteDto, storeId, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.INVALID_PARAMETER);
+
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository, never()).findAllById(any());
+            verify(storeNoticeRepository, never()).deleteAllById(any());
+        }
+
+        @Test
+        @DisplayName("사용자가 가게 권한이 없으면 예외가 발생한다")
+        void deleteNotice_UserHasNoPermission_ThrowsException() {
+            // given
+            List<Long> deleteIds = List.of(1L);
+            StoreNoticeDeleteDto deleteDto = new StoreNoticeDeleteDto(deleteIds);
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.deleteNotice(deleteDto, storeId, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOT_FOUND);
+
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository, never()).findAllById(any());
+            verify(storeNoticeRepository, never()).deleteAllById(any());
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added store notice management functionality enabling store owners to create, update, and delete notices for their stores
  * Customers can browse store notices with pagination support
  * Implemented secure access controls ensuring only authorized store owners can manage notices
  * Added error handling for missing or unauthorized notice access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->