### PR TITLE
refactor: StoreNotice 엔티티에 isRepresentative 필드명 변경 및 도메인 메서드를 추가했습니다

### DIFF
--- a/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
@@ -68,6 +68,7 @@ public enum ErrorMessage {
     SITE_CANNOT_NULL(BAD_REQUEST, "사이트 링크는 null일 수 없습니다."),
     STORE_NOTICE_NOT_FOUND(NOT_FOUND, "가게 공지사항을 찾을 수 없습니다."),
     STORE_NOTICE_ACCESS_DENIED(FORBIDDEN, "가게 공지사항 접근 권한이 없습니다."),
+    UNAUTHORIZED_STORE_NOTICE_ACCESS(FORBIDDEN, "해당 가게의 공지사항이 아닙니다."),
 
     // 메뉴 관련 에러
     MENU_NOT_FOUND(NOT_FOUND, "메뉴를 찾을 수 없습니다."),

--- a/src/main/java/com/example/chalpuplatform/common/test/BaseTimeEntity.java
+++ b/src/main/java/com/example/chalpuplatform/common/test/BaseTimeEntity.java
@@ -3,17 +3,22 @@ package com.example.chalpuplatform.common.test;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
 
     @CreatedDate
-    @Column(name ="createdAt", nullable = false)
+    @Column(name = "createdAt", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-
+    @LastModifiedDate
+    @Column(name = "updatedAt", nullable = false)
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/chalpuplatform/store/controller/StoreNoticeController.java
+++ b/src/main/java/com/example/chalpuplatform/store/controller/StoreNoticeController.java
@@ -112,4 +112,26 @@ public class StoreNoticeController {
         storeNoticeService.deleteNotice(storeNoticeDeleteDto, storeId,userDetails.getId());
         return ResponseEntity.ok(ApiResponse.success(null));
     }
+
+    /**
+     * 공지사항을 대표 공지로 설정합니다.
+     *
+     * @param storeId 가게 ID
+     * @param noticeId 공지사항 ID
+     * @return 설정된 대표 공지사항 정보
+     */
+    @PutMapping("/{storeId}/notices/{noticeId}/representative")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(
+            summary = "가게 공지사항을 대표 공지로 설정",
+            description = "특정 공지사항을 가게의 대표 공지로 설정합니다. 한 가게당 하나의 대표 공지만 존재할 수 있으며, 기존 대표 공지는 자동으로 해제됩니다. 매장 관리 권한이 필요합니다."
+    )
+    public ResponseEntity<ApiResponse<StoreNoticeResponse>> setRepresentativeNotice(
+            @PathVariable("storeId") Long storeId,
+            @PathVariable("noticeId") Long noticeId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        StoreNoticeResponse response = storeNoticeService.makeNoticeRepresentative(storeId, noticeId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 }

--- a/src/main/java/com/example/chalpuplatform/store/domain/StoreNotice.java
+++ b/src/main/java/com/example/chalpuplatform/store/domain/StoreNotice.java
@@ -27,15 +27,28 @@ public class StoreNotice extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String body;
 
+    @Column(name = "is_representative")
+    private Boolean isRepresentative;
+
     @Builder
-    public StoreNotice(Long storeId, String title, String body) {
+    public StoreNotice(Long storeId, String title, String body, Boolean isRepresentative) {
         this.storeId = storeId;
         this.title = title;
         this.body = body;
+        this.isRepresentative = isRepresentative != null ? isRepresentative : false;
     }
 
-    public void update(String title, String body) {
+    public void update(String title, String body,Boolean isRepresentative) {
         this.title = title;
         this.body = body;
+        this.isRepresentative = isRepresentative != null ? isRepresentative : this.isRepresentative;
+    }
+
+    public void makeRepresentative(){
+        this.isRepresentative = true;
+    }
+
+    public boolean belongsToStore(Long storeId){
+        return this.getStoreId().equals(storeId);
     }
 }

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreNoticeResponse.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreNoticeResponse.java
@@ -28,6 +28,9 @@ public class StoreNoticeResponse {
     @Schema(description = "공지사항 내용", example = "2024년 2월 9일부터 2월 12일까지 휴무입니다.")
     private String body;
 
+    @Schema(description = "대표 공지사항 여부", example = "true")
+    private Boolean isRepresentative;
+
     @Schema(description = "생성 시간")
     private LocalDateTime createdAt;
 
@@ -40,6 +43,7 @@ public class StoreNoticeResponse {
                 .storeId(storeNotice.getStoreId())
                 .title(storeNotice.getTitle())
                 .body(storeNotice.getBody())
+                .isRepresentative(storeNotice.getIsRepresentative())
                 .createdAt(storeNotice.getCreatedAt())
                 .updatedAt(storeNotice.getUpdatedAt())
                 .build();

--- a/src/main/java/com/example/chalpuplatform/store/dto/StoreNotiveRepresentativeDto.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/StoreNotiveRepresentativeDto.java
@@ -1,0 +1,13 @@
+package com.example.chalpuplatform.store.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreNotiveRepresentativeDto {
+    @Schema(description = "공지사항 ID",example = "1")
+    private Long storeNoticeId;
+}

--- a/src/main/java/com/example/chalpuplatform/store/dto/UpdateStoreNoticeRequest.java
+++ b/src/main/java/com/example/chalpuplatform/store/dto/UpdateStoreNoticeRequest.java
@@ -19,4 +19,7 @@ public class UpdateStoreNoticeRequest {
     @NotBlank
     @Schema(description = "공지사항 내용", example = "2024년 2월 9일부터 2월 12일까지 휴무입니다.")
     private String body;
+
+    @Schema(description = "대표 공지사항 여부", example = "true")
+    private Boolean isRepresentative;
 }

--- a/src/main/java/com/example/chalpuplatform/store/repository/StoreNoticeRepository.java
+++ b/src/main/java/com/example/chalpuplatform/store/repository/StoreNoticeRepository.java
@@ -6,8 +6,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StoreNoticeRepository extends JpaRepository<StoreNotice, Long> {
 
     Page<StoreNotice> findByStoreId(Long storeId, Pageable pageable);
+
+    Optional<StoreNotice> findByStoreIdAndIsRepresentativeTrue(Long storeId);
 }

--- a/src/main/java/com/example/chalpuplatform/store/service/StoreNoticeService.java
+++ b/src/main/java/com/example/chalpuplatform/store/service/StoreNoticeService.java
@@ -1,13 +1,11 @@
 package com.example.chalpuplatform.store.service;
 
 import com.example.chalpuplatform.common.exception.ErrorMessage;
+import com.example.chalpuplatform.common.exception.NoticeException;
 import com.example.chalpuplatform.common.exception.StoreException;
 import com.example.chalpuplatform.common.response.PageResponse;
 import com.example.chalpuplatform.store.domain.StoreNotice;
-import com.example.chalpuplatform.store.dto.CreateStoreNoticeRequest;
-import com.example.chalpuplatform.store.dto.StoreNoticeDeleteDto;
-import com.example.chalpuplatform.store.dto.StoreNoticeResponse;
-import com.example.chalpuplatform.store.dto.UpdateStoreNoticeRequest;
+import com.example.chalpuplatform.store.dto.*;
 import com.example.chalpuplatform.store.repository.StoreNoticeRepository;
 import com.example.chalpuplatform.store.repository.UserStoreRoleRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -45,6 +44,7 @@ public class StoreNoticeService {
                     .storeId(storeId)
                     .title(request.getTitle())
                     .body(request.getBody())
+                    .isRepresentative(false)
                     .build();
 
             StoreNotice savedNotice = storeNoticeRepository.save(notice);
@@ -97,7 +97,7 @@ public class StoreNoticeService {
             userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, notice.getStoreId())
                     .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
 
-            notice.update(request.getTitle(), request.getBody());
+            notice.update(request.getTitle(), request.getBody(), request.getIsRepresentative());
 
             log.info("event=store_notice_updated, notice_id={}, store_id={}", noticeId, notice.getStoreId());
             return StoreNoticeResponse.from(notice);
@@ -140,6 +140,45 @@ public class StoreNoticeService {
             throw e;
         } catch (Exception e) {
             log.error("event=store_notices_bulk_deletion_failed, error_message={}", e.getMessage(), e);
+            throw new StoreException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 공지사항을 대표 공지로 설정합니다.
+     * 한 가게당 하나의 대표 공지만 존재할 수 있으므로, 기존 대표 공지는 자동으로 해제됩니다.
+     *
+     * @param storeId 가게 ID
+     * @param noticeId 공지사항 ID
+     * @param userId 사용자 ID
+     * @return 설정된 대표 공지사항 정보
+     * @throws StoreException 권한이 없거나 공지사항을 찾을 수 없는 경우
+     */
+    public StoreNoticeResponse makeNoticeRepresentative(Long storeId, Long noticeId, Long userId) {
+        try {
+            userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+
+            StoreNotice storeNotice = storeNoticeRepository.findById(noticeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOTICE_NOT_FOUND));
+
+            if (!storeNotice.belongsToStore(storeId)) {
+                throw new StoreException(ErrorMessage.UNAUTHORIZED_STORE_NOTICE_ACCESS);
+            }
+
+            Optional<StoreNotice> existingRepresentative = storeNoticeRepository.findByStoreIdAndIsRepresentativeTrue(storeId);
+            existingRepresentative.ifPresent(representative ->
+                representative.update(representative.getTitle(), representative.getBody(), false)
+            );
+
+            storeNotice.makeRepresentative();
+
+            log.info("event=store_notice_set_representative, store_id={}, notice_id={}", storeId, noticeId);
+            return StoreNoticeResponse.from(storeNotice);
+        } catch (StoreException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("event=store_notice_set_representative_failed, store_id={}, notice_id={}, error_message={}", storeId, noticeId, e.getMessage(), e);
             throw new StoreException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/test/java/com/example/chalpuplatform/store/service/StoreNoticeServiceTest.java
+++ b/src/test/java/com/example/chalpuplatform/store/service/StoreNoticeServiceTest.java
@@ -69,7 +69,8 @@ class StoreNoticeServiceTest {
 
         updateRequest = new UpdateStoreNoticeRequest(
                 "추석 연휴 휴무 안내",
-                "2024년 9월 16일부터 9월 18일까지 휴무입니다."
+                "2024년 9월 16일부터 9월 18일까지 휴무입니다.",
+                false
         );
 
         pageable = PageRequest.of(0, 20);
@@ -97,6 +98,31 @@ class StoreNoticeServiceTest {
             assertThat(response.getTitle()).isEqualTo("설 연휴 휴무 안내");
             assertThat(response.getBody()).isEqualTo("2024년 2월 9일부터 2월 12일까지 휴무입니다.");
             verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository).save(any(StoreNotice.class));
+        }
+
+        @Test
+        @DisplayName("새 공지사항 생성 시 isRepresentative가 false로 설정된다")
+        void createNotice_IsRepresentativeDefaultFalse() {
+            // given
+            StoreNotice savedNotice = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title("설 연휴 휴무 안내")
+                    .body("2024년 2월 9일부터 2월 12일까지 휴무입니다.")
+                    .isRepresentative(false)
+                    .build();
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.save(any(StoreNotice.class)))
+                    .willReturn(savedNotice);
+
+            // when
+            StoreNoticeResponse response = storeNoticeService.createNotice(storeId, createRequest, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getIsRepresentative()).isFalse();
             verify(storeNoticeRepository).save(any(StoreNotice.class));
         }
 
@@ -348,6 +374,157 @@ class StoreNoticeServiceTest {
             verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
             verify(storeNoticeRepository, never()).findAllById(any());
             verify(storeNoticeRepository, never()).deleteAllById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("대표 공지사항 설정 테스트")
+    class MakeNoticeRepresentativeTest {
+
+        private StoreNotice targetNotice;
+        private StoreNotice existingRepresentativeNotice;
+        private Long noticeId = 1L;
+
+        @BeforeEach
+        void setUp() {
+            targetNotice = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title("신메뉴 출시 안내")
+                    .body("새로운 메뉴가 출시되었습니다.")
+                    .isRepresentative(false)
+                    .build();
+
+            existingRepresentativeNotice = StoreNotice.builder()
+                    .storeId(storeId)
+                    .title("기존 대표 공지")
+                    .body("기존 대표 공지 내용")
+                    .isRepresentative(true)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("대표 공지사항으로 성공적으로 설정한다")
+        void makeNoticeRepresentative_Success() {
+            // given
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.findById(noticeId))
+                    .willReturn(Optional.of(targetNotice));
+            given(storeNoticeRepository.findByStoreIdAndIsRepresentativeTrue(storeId))
+                    .willReturn(Optional.empty());
+
+            // when
+            StoreNoticeResponse response = storeNoticeService.makeNoticeRepresentative(storeId, noticeId, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTitle()).isEqualTo("신메뉴 출시 안내");
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository).findById(noticeId);
+            verify(storeNoticeRepository).findByStoreIdAndIsRepresentativeTrue(storeId);
+        }
+
+        @Test
+        @DisplayName("기존 대표 공지사항이 없을 때 대표로 설정한다")
+        void makeNoticeRepresentative_NoExistingRepresentative_Success() {
+            // given
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.findById(noticeId))
+                    .willReturn(Optional.of(targetNotice));
+            given(storeNoticeRepository.findByStoreIdAndIsRepresentativeTrue(storeId))
+                    .willReturn(Optional.empty());
+
+            // when
+            StoreNoticeResponse response = storeNoticeService.makeNoticeRepresentative(storeId, noticeId, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTitle()).isEqualTo("신메뉴 출시 안내");
+            verify(storeNoticeRepository).findByStoreIdAndIsRepresentativeTrue(storeId);
+        }
+
+        @Test
+        @DisplayName("기존 대표 공지사항이 있을 때 자동으로 해제하고 새로운 대표 공지를 설정한다")
+        void makeNoticeRepresentative_WithExistingRepresentative_Success() {
+            // given
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.findById(noticeId))
+                    .willReturn(Optional.of(targetNotice));
+            given(storeNoticeRepository.findByStoreIdAndIsRepresentativeTrue(storeId))
+                    .willReturn(Optional.of(existingRepresentativeNotice));
+
+            // when
+            StoreNoticeResponse response = storeNoticeService.makeNoticeRepresentative(storeId, noticeId, userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTitle()).isEqualTo("신메뉴 출시 안내");
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository).findById(noticeId);
+            verify(storeNoticeRepository).findByStoreIdAndIsRepresentativeTrue(storeId);
+        }
+
+        @Test
+        @DisplayName("사용자가 가게 권한이 없으면 예외가 발생한다")
+        void makeNoticeRepresentative_UserHasNoPermission_ThrowsException() {
+            // given
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.makeNoticeRepresentative(storeId, noticeId, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOT_FOUND);
+
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository, never()).findById(anyLong());
+        }
+
+        @Test
+        @DisplayName("공지사항을 찾을 수 없으면 예외가 발생한다")
+        void makeNoticeRepresentative_NoticeNotFound_ThrowsException() {
+            // given
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.findById(noticeId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.makeNoticeRepresentative(storeId, noticeId, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.STORE_NOTICE_NOT_FOUND);
+
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository).findById(noticeId);
+            verify(storeNoticeRepository, never()).findByStoreIdAndIsRepresentativeTrue(anyLong());
+        }
+
+        @Test
+        @DisplayName("다른 가게의 공지사항에 접근하면 예외가 발생한다")
+        void makeNoticeRepresentative_UnauthorizedAccess_ThrowsException() {
+            // given
+            StoreNotice otherStoreNotice = StoreNotice.builder()
+                    .storeId(999L)
+                    .title("다른 가게 공지")
+                    .body("다른 가게의 공지사항")
+                    .isRepresentative(false)
+                    .build();
+
+            given(userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId))
+                    .willReturn(Optional.of(mock(UserStoreRole.class)));
+            given(storeNoticeRepository.findById(noticeId))
+                    .willReturn(Optional.of(otherStoreNotice));
+
+            // when & then
+            assertThatThrownBy(() -> storeNoticeService.makeNoticeRepresentative(storeId, noticeId, userId))
+                    .isInstanceOf(StoreException.class)
+                    .hasFieldOrPropertyWithValue("errorMessage", ErrorMessage.UNAUTHORIZED_STORE_NOTICE_ACCESS);
+
+            verify(userStoreRoleRepository).findByUserIdAndStoreIdAndIsActiveTrue(userId, storeId);
+            verify(storeNoticeRepository).findById(noticeId);
+            verify(storeNoticeRepository, never()).findByStoreIdAndIsRepresentativeTrue(anyLong());
         }
     }
 }


### PR DESCRIPTION
# 가게 공지사항 API 가이드

## 개요

가게 공지사항 API는 가게의 공지사항을 생성, 수정, 조회, 삭제할 수 있으며, 특정 공지사항을 대표 공지로 설정할 수 있습니다.

## 주요 개념

### 대표 공지사항 (Representative Notice)

- 한 가게당 **하나의 대표 공지사항만** 존재할 수 있습니다
- 대표 공지사항은 클라이언트에서 상단에 고정 표시하거나 강조 표시할 수 있습니다
- 새로운 공지사항을 대표로 설정하면, 기존 대표 공지사항은 자동으로 일반 공지사항으로 변경됩니다

---

## API 엔드포인트

### 1. 공지사항 생성

**Endpoint**
```
POST /api/stores/{storeId}/notices
```

**권한**
- OWNER 역할 필요

**Request Body**
```json
{
  "title": "설 연휴 휴무 안내",
  "body": "2024년 2월 9일부터 2월 12일까지 휴무입니다."
}
```

**Response**
```json
{
  "code": 200,
  "message": "API 요청이 성공했습니다.",
  "result": {
    "id": 1,
    "storeId": 1,
    "title": "설 연휴 휴무 안내",
    "body": "2024년 2월 9일부터 2월 12일까지 휴무입니다.",
    "isRepresentative": false,
    "createdAt": "2024-01-15T10:30:00",
    "updatedAt": "2024-01-15T10:30:00"
  }
}
```

**동작 방식**
1. 새로운 공지사항이 생성됩니다
2. `isRepresentative`는 기본적으로 `false`로 설정됩니다
3. 대표 공지로 설정하려면 별도의 API를 호출해야 합니다

---

### 2. 공지사항 수정

**Endpoint**
```
PUT /api/stores/notices/{noticeId}
```

**권한**
- OWNER 역할 필요

**Request Body**
```json
{
  "title": "추석 연휴 휴무 안내",
  "body": "2024년 9월 16일부터 9월 18일까지 휴무입니다.",
  "isRepresentative": false
}
```

**Response**
```json
{
  "code": 200,
  "message": "API 요청이 성공했습니다.",
  "result": {
    "id": 1,
    "storeId": 1,
    "title": "추석 연휴 휴무 안내",
    "body": "2024년 9월 16일부터 9월 18일까지 휴무입니다.",
    "isRepresentative": false,
    "createdAt": "2024-01-15T10:30:00",
    "updatedAt": "2024-01-20T14:20:00"
  }
}
```

**동작 방식**
1. 제목과 내용을 수정할 수 있습니다
2. `isRepresentative`를 `false`로 설정하면 대표 공지에서 해제됩니다
3. `isRepresentative`를 `true`로 설정해도 대표 공지로 설정되지만, **별도의 대표 공지 설정 API 사용을 권장**합니다

> **참고**: 수정 API로 대표 공지 설정 시 기존 대표 공지가 자동으로 해제되지 않습니다. 대표 공지 설정 전용 API를 사용하는 것을 권장합니다.

---

### 3. 대표 공지사항 설정 (권장)

**Endpoint**
```
PUT /api/stores/{storeId}/notices/{noticeId}/representative
```

**권한**
- OWNER 역할 필요

**Request Body**
- 없음 (URL 파라미터로만 동작)

**Response**
```json
{
  "code": 200,
  "message": "API 요청이 성공했습니다.",
  "result": {
    "id": 1,
    "storeId": 1,
    "title": "추석 연휴 휴무 안내",
    "body": "2024년 9월 16일부터 9월 18일까지 휴무입니다.",
    "isRepresentative": true,
    "createdAt": "2024-01-15T10:30:00",
    "updatedAt": "2024-01-20T14:20:00"
  }
}
```

**동작 방식**
1. 해당 공지사항을 대표 공지로 설정합니다
2. **기존에 대표 공지가 있었다면, 자동으로 일반 공지로 변경됩니다**
3. 한 가게에는 항상 최대 1개의 대표 공지만 존재합니다

**시나리오 예시**

#### 시나리오 1: 대표 공지가 없는 경우
```
초기 상태:
- 공지사항 A (isRepresentative: false)
- 공지사항 B (isRepresentative: false)

API 호출: PUT /api/stores/1/notices/1/representative

결과:
- 공지사항 A (isRepresentative: true)  ← 대표 공지로 설정됨
- 공지사항 B (isRepresentative: false)
```

#### 시나리오 2: 대표 공지가 이미 존재하는 경우
```
초기 상태:
- 공지사항 A (isRepresentative: true)  ← 기존 대표 공지
- 공지사항 B (isRepresentative: false)

API 호출: PUT /api/stores/1/notices/2/representative

결과:
- 공지사항 A (isRepresentative: false) ← 자동으로 일반 공지로 변경
- 공지사항 B (isRepresentative: true)  ← 새로운 대표 공지
```

---

## 클라이언트 구현 가이드

### 1. 공지사항 생성 플로우

```javascript
// 1단계: 공지사항 생성
const response = await fetch('/api/stores/1/notices', {
  method: 'POST',
  headers: {
    'Content-Type': 'application/json',
    'Authorization': 'Bearer {token}'
  },
  body: JSON.stringify({
    title: '신규 공지사항',
    body: '공지 내용입니다.'
  })
});

const data = await response.json();
console.log(data.result.isRepresentative); // false

// 2단계 (선택): 대표 공지로 설정하려면
if (needToSetAsRepresentative) {
  await fetch(`/api/stores/1/notices/${data.result.id}/representative`, {
    method: 'PUT',
    headers: {
      'Authorization': 'Bearer {token}'
    }
  });
}
```

### 2. 공지사항 수정 플로우

```javascript
// 일반 수정: 제목과 내용만 변경
await fetch('/api/stores/notices/1', {
  method: 'PUT',
  headers: {
    'Content-Type': 'application/json',
    'Authorization': 'Bearer {token}'
  },
  body: JSON.stringify({
    title: '수정된 제목',
    body: '수정된 내용',
    isRepresentative: false // 현재 상태 유지
  })
});
```

### 3. 대표 공지 설정 플로우

```javascript
// 대표 공지로 설정 (기존 대표 공지는 자동으로 해제됨)
await fetch('/api/stores/1/notices/1/representative', {
  method: 'PUT',
  headers: {
    'Authorization': 'Bearer {token}'
  }
});

// 이후 공지사항 목록을 다시 조회하면
// 해당 공지만 isRepresentative: true
// 나머지는 모두 isRepresentative: false
```

### 4. UI 표시 권장사항

```javascript
// 공지사항 목록 렌더링
notices.forEach(notice => {
  if (notice.isRepresentative) {
    // 대표 공지사항은 상단 고정 또는 배지 표시
    renderPinnedNotice(notice);
  } else {
    renderNormalNotice(notice);
  }
});
```

---

## 에러 처리

### 권한 없음
```json
{
  "code": 403,
  "message": "매장을 찾을 수 없습니다."
}
```

### 공지사항 없음
```json
{
  "code": 404,
  "message": "가게 공지사항을 찾을 수 없습니다."
}
```

### 다른 가게의 공지사항 접근
```json
{
  "code": 403,
  "message": "해당 가게의 공지사항이 아닙니다."
}
```

---

## 요약

### 공지사항 생성
- 기본적으로 `isRepresentative: false`로 생성됩니다
- 대표 공지로 만들려면 별도 API 호출이 필요합니다

### 공지사항 수정
- 제목, 내용, 대표 공지 여부를 변경할 수 있습니다
- `isRepresentative`를 `false`로 설정하면 대표 공지에서 해제됩니다
- 수정 API로도 대표 공지 설정이 가능하지만, 전용 API 사용을 권장합니다

### 대표 공지사항 설정 (전용 API)
- 전용 API를 사용하면 기존 대표 공지가 자동으로 해제됩니다
- 한 가게당 최대 1개의 대표 공지만 유지됩니다
- 가장 안전하고 명확한 방법입니다

### 권장 플로우
1. 공지사항 생성 API 호출
2. 대표 공지로 만들어야 한다면 → 대표 공지 설정 API 호출
3. 대표 공지를 변경하려면 → 새 공지사항의 대표 공지 설정 API 호출 (기존 대표 공지 자동 해제)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store owners can now designate a specific store notice as the featured/representative notice for their store
  * Improved error handling with specific messaging for unauthorized store notice access
  * Added enhanced timestamp tracking for store notice modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->