### PR TITLE
refactor: 사장님이 메뉴의 활성 질문을 삭제할 수 있는 api 생성

### DIFF
--- a/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chalpuplatform/common/exception/ErrorMessage.java
@@ -197,6 +197,7 @@ public enum ErrorMessage {
     SURVEY_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "설문 질문을 찾을 수 없습니다."),
     SURVEY_ANSWER_INVALID(HttpStatus.BAD_REQUEST, "설문 답변이 유효하지 않습니다."),
     SURVEY_MUST_CONTAIN_FORCEOMESSAGE(BAD_REQUEST, "사장님에게 한마디 메세지는 필수 질문 요소입니다."),
+    SURVEY_QUESTION_DELETE_FAIL(BAD_REQUEST, "삭제에 실패했습니다."),
 
     // Reward 관련 에러
     REWARD_NOT_FOUND(HttpStatus.NOT_FOUND, "리워드를 찾을 수 없습니다."),

--- a/src/main/java/com/example/chalpuplatform/fooditem/controller/FoodItemQuestionController.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/controller/FoodItemQuestionController.java
@@ -46,6 +46,20 @@ public class FoodItemQuestionController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @DeleteMapping("/{foodItemId}/question-off")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(
+            summary = "사장님이 메뉴의 활성화 질문을 삭제하는 API",
+            description = "특정 메뉴의 활성 질문을 다 삭제합니다."
+    )
+    public ResponseEntity<ApiResponse<Void>> deleteActiveQuestions(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable("foodItemId") Long foodItemId
+    ){
+        foodItemQuestionService.deleteActiveQuestions(foodItemId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success("삭제에 성공했습니다.",null));
+    }
+
     @GetMapping("/{foodItemId}/active-questions")
     @Operation(
             summary = "메뉴별 활성화된 질문 조회",

--- a/src/main/java/com/example/chalpuplatform/fooditem/repository/FoodItemQuestionRepository.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/repository/FoodItemQuestionRepository.java
@@ -33,4 +33,11 @@ public interface FoodItemQuestionRepository extends JpaRepository<FoodItemQuesti
 
     @Modifying
     void deleteByFoodItem(FoodItem foodItem);
+
+    @Modifying
+    @Query(
+            "DELETE FROM FoodItemQuestion fiq "+
+            "WHERE fiq.foodItem.id = :foodItemId"
+    )
+    void deleteByFoodItemId(Long foodItemId);
 }

--- a/src/main/java/com/example/chalpuplatform/fooditem/service/FoodItemQuestionService.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/service/FoodItemQuestionService.java
@@ -116,4 +116,14 @@ public class FoodItemQuestionService {
             throw new StoreException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
     }
+
+    public void deleteActiveQuestions(Long foodItemId, Long userId) {
+            FoodItem foodItem = foodItemRepository.findById(foodItemId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.FOOD_NOT_FOUND));
+
+            userStoreRoleRepository.findByUserIdAndStoreIdAndIsActiveTrue(userId, foodItem.getStore().getId())
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+
+            foodItemQuestionRepository.deleteByFoodItemId(foodItemId);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Food item owners can now delete questions associated with their food items through a new API endpoint.
  * Enhanced error messaging for failed deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->