### PR TITLE
fix: 메뉴 중복 체크 시 NonUniqueResultException 에러를 수정했습니다

### DIFF
--- a/src/main/java/com/example/chalpuplatform/fooditem/repository/FoodItemRepository.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/repository/FoodItemRepository.java
@@ -29,8 +29,8 @@ public interface FoodItemRepository extends JpaRepository<FoodItem, Long> {
     Optional<Long> findStoreIdByFoodItemId(@Param("id") Long id);
 
     // 메뉴 추출을 위한 중복 체크용 메서드
-    @Query("SELECT fi FROM FoodItem fi WHERE fi.store.id = :storeId AND fi.foodName = :foodName AND fi.isActive = true")
-    Optional<FoodItem> findByStoreIdAndFoodName(@Param("storeId") Long storeId, @Param("foodName") String foodName);
+    @Query("SELECT CASE WHEN COUNT(fi) > 0 THEN true ELSE false END FROM FoodItem fi WHERE fi.store.id = :storeId AND fi.foodName = :foodName AND fi.isActive = true")
+    boolean existsByStoreIdAndFoodName(@Param("storeId") Long storeId, @Param("foodName") String foodName);
 
     @Modifying
     @Query("UPDATE FoodItem f SET f.feedbackCount = f.feedbackCount + 1 WHERE f.id = :foodItemId")

--- a/src/main/java/com/example/chalpuplatform/fooditem/service/MenuPersistenceService.java
+++ b/src/main/java/com/example/chalpuplatform/fooditem/service/MenuPersistenceService.java
@@ -71,8 +71,8 @@ public class MenuPersistenceService {
 
         for (ExtractedFoodItemDto item : extractedItems) {
             // 기존 아이템 확인 (이름으로 중복 체크)
-            boolean exists = foodItemRepository.findByStoreIdAndFoodName(
-                    store.getId(), item.getName()).isPresent();
+            boolean exists = foodItemRepository.existsByStoreIdAndFoodName(
+                    store.getId(), item.getName());
 
             if (!exists) {
                 FoodItem foodItem = FoodItem.builder()


### PR DESCRIPTION
- FoodItemRepository의 findByStoreIdAndFoodName을 existsByStoreIdAndFoodName으로 변경
- 중복된 메뉴 아이템이 존재할 때 발생하는 NonUniqueResultException 해결
- 존재 여부만 확인하므로 boolean 반환으로 성능 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the menu item duplicate detection mechanism for improved performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->